### PR TITLE
Fix the problem with headers passthrough

### DIFF
--- a/src/WireMock.Net/Http/HttpClientHelper.cs
+++ b/src/WireMock.Net/Http/HttpClientHelper.cs
@@ -58,7 +58,7 @@ namespace WireMock.Http
             {
                 foreach (var headerName in requestMessage.Headers.Keys.Where(k => k.ToUpper() != "HOST"))
                 {
-                    httpRequestMessage.Headers.Add(headerName, new[] { requestMessage.Headers[headerName] });
+                    httpRequestMessage.Headers.TryAddWithoutValidation(headerName, new[] { requestMessage.Headers[headerName] });
                 }
             }
 


### PR DESCRIPTION
Proxy didn't process some headers correctly.
1. `Content-*` headers can't be set manually with validation
2. Valid AWS `Authorization-*` header required validation

Reproduce:
1. Create Wiremock instance
2. Start local DynamoDb
3. Proxy all requests to DynamoDb
4. Create any request with DynamoDb API

