### PR TITLE
Add ability to provide multiple values for headers in response

### DIFF
--- a/examples/WireMock.Net.Console.NETCoreApp/__admin/mappings/11111110-a633-40e8-a244-5cb80bc0ab66.json
+++ b/examples/WireMock.Net.Console.NETCoreApp/__admin/mappings/11111110-a633-40e8-a244-5cb80bc0ab66.json
@@ -14,8 +14,9 @@
     },
     "Response": {
         "BodyAsJson": { "body": "static mapping" },
-        "Headers": {
-            "Content-Type": "application/json"
-        }
+      "Headers": {
+        "Content-Type": "application/json",
+        "Test-X": [ "test 1", "test 2" ]
+      }
     }
 }

--- a/examples/WireMock.Net.ConsoleApplication/MainApp.cs
+++ b/examples/WireMock.Net.ConsoleApplication/MainApp.cs
@@ -31,6 +31,13 @@ namespace WireMock.Net.ConsoleApplication
             // server.AllowPartialMapping();
 
             server
+                .Given(Request.Create().WithPath("/headers", "/headers_test").UsingPost().WithHeader("Content-Type", "application/json*"))
+                .RespondWith(Response.Create()
+                    .WithStatusCode(201)
+                    .WithHeader("MyHeader", "application/json", "application/json2")
+                    .WithBody(@"{ ""result"": ""data posted with 201""}"));
+
+            server
                 .Given(Request.Create().WithPath("/file").UsingGet())
                 .RespondWith(Response.Create()
                     .WithBodyFromFile(@"c:\temp\x.json", false)
@@ -85,13 +92,6 @@ namespace WireMock.Net.ConsoleApplication
                     .WithStatusCode(201)
                     .WithHeader("Content-Type", "application/json")
                     .WithBody(@"{ ""result"": ""data posted with FUNC 201""}"));
-
-            server
-                .Given(Request.Create().WithPath("/data", "/ax").UsingPost().WithHeader("Content-Type", "application/json*"))
-                .RespondWith(Response.Create()
-                    .WithStatusCode(201)
-                    .WithHeader("Content-Type", "application/json")
-                    .WithBody(@"{ ""result"": ""data posted with 201""}"));
 
             server
                 .Given(Request.Create().WithPath("/json").UsingPost().WithBody(new JsonPathMatcher("$.things[?(@.name == 'RequiredThing')]")))

--- a/src/WireMock.Net/Admin/Mappings/ResponseModel.cs
+++ b/src/WireMock.Net/Admin/Mappings/ResponseModel.cs
@@ -60,7 +60,7 @@ namespace WireMock.Admin.Mappings
         /// <summary>
         /// Gets or sets the headers.
         /// </summary>
-        public IDictionary<string, string> Headers { get; set; }
+        public IDictionary<string, object> Headers { get; set; }
 
         /// <summary>
         /// Gets or sets the Headers (Raw).

--- a/src/WireMock.Net/Admin/Requests/LogRequestModel.cs
+++ b/src/WireMock.Net/Admin/Requests/LogRequestModel.cs
@@ -43,7 +43,7 @@ namespace WireMock.Admin.Requests
         /// <summary>
         /// Gets or sets the Headers.
         /// </summary>
-        public IDictionary<string, string> Headers { get; set; }
+        public IDictionary<string, WireMockList<string>> Headers { get; set; }
 
         /// <summary>
         /// Gets or sets the Cookies.

--- a/src/WireMock.Net/Admin/Requests/LogResponseModel.cs
+++ b/src/WireMock.Net/Admin/Requests/LogResponseModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using WireMock.Admin.Mappings;
+using WireMock.Util;
 
 namespace WireMock.Admin.Requests
 {
@@ -16,7 +17,7 @@ namespace WireMock.Admin.Requests
         /// <summary>
         /// Gets the headers.
         /// </summary>
-        public IDictionary<string, string[]> Headers { get; set; }
+        public IDictionary<string, WireMockList<string>> Headers { get; set; }
 
         /// <summary>
         /// Gets or sets the body destination (SameAsSource, String or Bytes).

--- a/src/WireMock.Net/Admin/Requests/LogResponseModel.cs
+++ b/src/WireMock.Net/Admin/Requests/LogResponseModel.cs
@@ -16,7 +16,7 @@ namespace WireMock.Admin.Requests
         /// <summary>
         /// Gets the headers.
         /// </summary>
-        public IDictionary<string, string> Headers { get; set; }
+        public IDictionary<string, string[]> Headers { get; set; }
 
         /// <summary>
         /// Gets or sets the body destination (SameAsSource, String or Bytes).

--- a/src/WireMock.Net/Http/HttpClientHelper.cs
+++ b/src/WireMock.Net/Http/HttpClientHelper.cs
@@ -52,7 +52,7 @@ namespace WireMock.Http
             {
                 foreach (var headerName in requestMessage.Headers.Keys.Where(k => k.ToUpper() != "HOST"))
                 {
-                    httpRequestMessage.Headers.TryAddWithoutValidation(headerName, new[] { requestMessage.Headers[headerName] });
+                    httpRequestMessage.Headers.TryAddWithoutValidation(headerName, requestMessage.Headers[headerName]);
                 }
             }
 

--- a/src/WireMock.Net/Owin/OwinRequestMapper.cs
+++ b/src/WireMock.Net/Owin/OwinRequestMapper.cs
@@ -57,13 +57,13 @@ namespace WireMock.Owin
                 body = bodyEncoding.GetBytes(bodyAsString);
             }
 
-            Dictionary<string, string> headers = null;
+            Dictionary<string, string[]> headers = null;
             if (request.Headers.Any())
             {
-                headers = new Dictionary<string, string>();
+                headers = new Dictionary<string, string[]>();
                 foreach (var header in request.Headers)
                 {
-                    headers.Add(header.Key, header.Value.FirstOrDefault());
+                    headers.Add(header.Key, header.Value);
                 }
             }
 

--- a/src/WireMock.Net/Owin/OwinResponseMapper.cs
+++ b/src/WireMock.Net/Owin/OwinResponseMapper.cs
@@ -35,14 +35,15 @@ namespace WireMock.Owin
 
             if (responseMessage.Headers.ContainsKey(HttpKnownHeaderNames.ContentType))
             {
-                response.ContentType = responseMessage.Headers[HttpKnownHeaderNames.ContentType][0];
+                response.ContentType = responseMessage.Headers[HttpKnownHeaderNames.ContentType].FirstOrDefault();
             }
+
             var headers = responseMessage.Headers.Where(h => h.Key != HttpKnownHeaderNames.ContentType).ToList();
 
 #if !NETSTANDARD
-            headers.ForEach(pair => response.Headers.AppendValues(pair.Key, pair.Value));
+            headers.ForEach(pair => response.Headers.AppendValues(pair.Key, pair.Value.ToArray()));
 #else
-            headers.ForEach(pair => response.Headers.Append(pair.Key, pair.Value));
+            headers.ForEach(pair => response.Headers.Append(pair.Key, pair.Value.ToArray()));
 #endif
 
             if (responseMessage.Body == null && responseMessage.BodyAsBytes == null && responseMessage.BodyAsFile == null)

--- a/src/WireMock.Net/Owin/WireMockMiddleware.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddleware.cs
@@ -4,6 +4,7 @@ using WireMock.Logging;
 using WireMock.Matchers.Request;
 using System.Linq;
 using WireMock.Matchers;
+using WireMock.Util;
 #if !NETSTANDARD
 using Microsoft.Owin;
 #else
@@ -101,8 +102,8 @@ namespace WireMock.Owin
 
                 if (targetMapping.IsAdminInterface && _options.AuthorizationMatcher != null)
                 {
-                    bool present = request.Headers.TryGetValue("Authorization", out string authorization);
-                    if (!present || _options.AuthorizationMatcher.IsMatch(authorization) < MatchScores.Perfect)
+                    bool present = request.Headers.TryGetValue("Authorization", out WireMockList<string> authorization);
+                    if (!present || _options.AuthorizationMatcher.IsMatch(authorization.ToString()) < MatchScores.Perfect)
                     {
                         response = new ResponseMessage { StatusCode = 401 };
                         return;

--- a/src/WireMock.Net/RequestBuilders/IHeadersAndCookiesRequestBuilder.cs
+++ b/src/WireMock.Net/RequestBuilders/IHeadersAndCookiesRequestBuilder.cs
@@ -33,7 +33,7 @@ namespace WireMock.RequestBuilders
         /// </summary>
         /// <param name="funcs">The headers funcs.</param>
         /// <returns>The <see cref="IRequestBuilder"/>.</returns>
-        IRequestBuilder WithHeader([NotNull] params Func<IDictionary<string, string>, bool>[] funcs);
+        IRequestBuilder WithHeader([NotNull] params Func<IDictionary<string, string[]>, bool>[] funcs);
 
         /// <summary>
         /// The with cookie.

--- a/src/WireMock.Net/RequestBuilders/Request.cs
+++ b/src/WireMock.Net/RequestBuilders/Request.cs
@@ -395,7 +395,7 @@ namespace WireMock.RequestBuilders
         /// </summary>
         /// <param name="funcs">The funcs.</param>
         /// <returns>The <see cref="IRequestBuilder"/>.</returns>
-        public IRequestBuilder WithHeader(params Func<IDictionary<string, string>, bool>[] funcs)
+        public IRequestBuilder WithHeader(params Func<IDictionary<string, string[]>, bool>[] funcs)
         {
             Check.NotEmpty(funcs, nameof(funcs));
 

--- a/src/WireMock.Net/RequestMessage.cs
+++ b/src/WireMock.Net/RequestMessage.cs
@@ -41,7 +41,7 @@ namespace WireMock
         /// <summary>
         /// Gets the headers.
         /// </summary>
-        public IDictionary<string, string> Headers { get; }
+        public IDictionary<string, WireMockList<string>> Headers { get; }
 
         /// <summary>
         /// Gets the cookies.
@@ -79,7 +79,7 @@ namespace WireMock
         /// <param name="bodyEncoding">The body encoding</param>
         /// <param name="headers">The headers.</param>
         /// <param name="cookies">The cookies.</param>
-        public RequestMessage([NotNull] Uri url, [NotNull] string method, [NotNull] string clientIP, [CanBeNull] byte[] bodyAsBytes = null, [CanBeNull] string body = null, [CanBeNull] Encoding bodyEncoding = null, [CanBeNull] IDictionary<string, string> headers = null, [CanBeNull] IDictionary<string, string> cookies = null)
+        public RequestMessage([NotNull] Uri url, [NotNull] string method, [NotNull] string clientIP, [CanBeNull] byte[] bodyAsBytes = null, [CanBeNull] string body = null, [CanBeNull] Encoding bodyEncoding = null, [CanBeNull] IDictionary<string, string[]> headers = null, [CanBeNull] IDictionary<string, string> cookies = null)
         {
             Check.NotNull(url, nameof(url));
             Check.NotNull(method, nameof(method));
@@ -92,7 +92,7 @@ namespace WireMock
             BodyAsBytes = bodyAsBytes;
             Body = body;
             BodyEncoding = bodyEncoding;
-            Headers = headers;
+            Headers = headers?.ToDictionary(header => header.Key, header => new WireMockList<string>(header.Value));
             Cookies = cookies;
             Query = ParseQuery(url.Query);
         }

--- a/src/WireMock.Net/ResponseBuilders/IHeadersResponseBuilder.cs
+++ b/src/WireMock.Net/ResponseBuilders/IHeadersResponseBuilder.cs
@@ -17,10 +17,25 @@ namespace WireMock.ResponseBuilders
         IResponseBuilder WithHeader([NotNull] string name, string value);
 
         /// <summary>
+        /// The with header.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="values">The values.</param>
+        /// <returns>The <see cref="IResponseBuilder"/>.</returns>
+        IResponseBuilder WithHeader([NotNull] string name, string[] values);
+
+        /// <summary>
         /// The with headers.
         /// </summary>
         /// <param name="headers">The headers.</param>
         /// <returns>The <see cref="IResponseBuilder"/>.</returns>
-        IResponseBuilder WithHeaders([NotNull] IDictionary<string,string> headers);
+        IResponseBuilder WithHeaders([NotNull] IDictionary<string, string> headers);
+
+        /// <summary>
+        /// The with headers.
+        /// </summary>
+        /// <param name="headers">The headers.</param>
+        /// <returns>The <see cref="IResponseBuilder"/>.</returns>
+        IResponseBuilder WithHeaders([NotNull] IDictionary<string, string[]> headers);
     }
 }

--- a/src/WireMock.Net/ResponseBuilders/IHeadersResponseBuilder.cs
+++ b/src/WireMock.Net/ResponseBuilders/IHeadersResponseBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using JetBrains.Annotations;
+using WireMock.Util;
 
 namespace WireMock.ResponseBuilders
 {
@@ -12,17 +13,9 @@ namespace WireMock.ResponseBuilders
         /// The with header.
         /// </summary>
         /// <param name="name">The name.</param>
-        /// <param name="value">The value.</param>
-        /// <returns>The <see cref="IResponseBuilder"/>.</returns>
-        IResponseBuilder WithHeader([NotNull] string name, string value);
-
-        /// <summary>
-        /// The with header.
-        /// </summary>
-        /// <param name="name">The name.</param>
         /// <param name="values">The values.</param>
         /// <returns>The <see cref="IResponseBuilder"/>.</returns>
-        IResponseBuilder WithHeader([NotNull] string name, string[] values);
+        IResponseBuilder WithHeader([NotNull] string name, params string[] values);
 
         /// <summary>
         /// The with headers.
@@ -37,5 +30,12 @@ namespace WireMock.ResponseBuilders
         /// <param name="headers">The headers.</param>
         /// <returns>The <see cref="IResponseBuilder"/>.</returns>
         IResponseBuilder WithHeaders([NotNull] IDictionary<string, string[]> headers);
+
+        /// <summary>
+        /// The with headers.
+        /// </summary>
+        /// <param name="headers">The headers.</param>
+        /// <returns>The <see cref="IResponseBuilder"/>.</returns>
+        IResponseBuilder WithHeaders([NotNull] IDictionary<string, WireMockList<string>> headers);
     }
 }

--- a/src/WireMock.Net/ResponseBuilders/Response.cs
+++ b/src/WireMock.Net/ResponseBuilders/Response.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
-using WireMock.Validation;
 using WireMock.Http;
 using WireMock.Transformers;
+using WireMock.Validation;
 
 namespace WireMock.ResponseBuilders
 {
@@ -140,8 +141,25 @@ namespace WireMock.ResponseBuilders
             return this;
         }
 
-        /// <inheritdoc cref="IHeadersResponseBuilder.WithHeaders"/>
+        /// <inheritdoc cref="IHeadersResponseBuilder.WithHeader(string, string[])"/>
+        public IResponseBuilder WithHeader([NotNull] string name, string[] values)
+        {
+            Check.NotNull(name, nameof(name));
+
+            ResponseMessage.AddHeader(name, values);
+            return this;
+        }
+
+        /// <inheritdoc cref="IHeadersResponseBuilder.WithHeaders(IDictionary{string, string})"/>
         public IResponseBuilder WithHeaders(IDictionary<string, string> headers)
+        {
+            var headersValues = headers.ToDictionary(header => header.Key, header => new[] { header.Value });
+            ResponseMessage.Headers = headersValues;
+            return this;
+        }
+
+        /// <inheritdoc cref="IHeadersResponseBuilder.WithHeaders(IDictionary{string, string[]})"/>
+        public IResponseBuilder WithHeaders(IDictionary<string, string[]> headers)
         {
             ResponseMessage.Headers = headers;
             return this;

--- a/src/WireMock.Net/ResponseBuilders/Response.cs
+++ b/src/WireMock.Net/ResponseBuilders/Response.cs
@@ -9,6 +9,7 @@ using JetBrains.Annotations;
 using Newtonsoft.Json;
 using WireMock.Http;
 using WireMock.Transformers;
+using WireMock.Util;
 using WireMock.Validation;
 
 namespace WireMock.ResponseBuilders
@@ -127,22 +128,8 @@ namespace WireMock.ResponseBuilders
             return WithStatusCode((int)HttpStatusCode.NotFound);
         }
 
-        /// <summary>
-        /// The with header.
-        /// </summary>
-        /// <param name="name">The name.</param>
-        /// <param name="value">The value.</param>
-        /// <returns>The <see cref="IResponseBuilder"/>.</returns>
-        public IResponseBuilder WithHeader(string name, string value)
-        {
-            Check.NotNull(name, nameof(name));
-
-            ResponseMessage.AddHeader(name, value);
-            return this;
-        }
-
         /// <inheritdoc cref="IHeadersResponseBuilder.WithHeader(string, string[])"/>
-        public IResponseBuilder WithHeader([NotNull] string name, string[] values)
+        public IResponseBuilder WithHeader(string name, params string[] values)
         {
             Check.NotNull(name, nameof(name));
 
@@ -153,13 +140,23 @@ namespace WireMock.ResponseBuilders
         /// <inheritdoc cref="IHeadersResponseBuilder.WithHeaders(IDictionary{string, string})"/>
         public IResponseBuilder WithHeaders(IDictionary<string, string> headers)
         {
-            var headersValues = headers.ToDictionary(header => header.Key, header => new[] { header.Value });
-            ResponseMessage.Headers = headersValues;
+            Check.NotNull(headers, nameof(headers));
+
+            ResponseMessage.Headers = headers.ToDictionary(header => header.Key, header => new WireMockList<string>(header.Value));
             return this;
         }
 
         /// <inheritdoc cref="IHeadersResponseBuilder.WithHeaders(IDictionary{string, string[]})"/>
         public IResponseBuilder WithHeaders(IDictionary<string, string[]> headers)
+        {
+            Check.NotNull(headers, nameof(headers));
+
+            ResponseMessage.Headers = headers.ToDictionary(header => header.Key, header => new WireMockList<string>(header.Value));
+            return this;
+        }
+
+        /// <inheritdoc cref="IHeadersResponseBuilder.WithHeaders(IDictionary{string, WireMockList{string}})"/>
+        public IResponseBuilder WithHeaders(IDictionary<string, WireMockList<string>> headers)
         {
             ResponseMessage.Headers = headers;
             return this;

--- a/src/WireMock.Net/ResponseMessage.cs
+++ b/src/WireMock.Net/ResponseMessage.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using WireMock.Validation;
 
 namespace WireMock
 {
@@ -12,7 +14,7 @@ namespace WireMock
         /// <summary>
         /// Gets the headers.
         /// </summary>
-        public IDictionary<string, string> Headers { get; set; } = new ConcurrentDictionary<string, string>();
+        public IDictionary<string, string[]> Headers { get; set; } = new ConcurrentDictionary<string, string[]>();
 
         /// <summary>
         /// Gets or sets the status code.
@@ -55,7 +57,7 @@ namespace WireMock
         public Encoding BodyEncoding { get; set; } = new UTF8Encoding(false);
 
         /// <summary>
-        /// The add header.
+        /// Add header.
         /// </summary>
         /// <param name="name">
         /// The name.
@@ -65,7 +67,27 @@ namespace WireMock
         /// </param>
         public void AddHeader(string name, string value)
         {
-            Headers.Add(name, value);
+            Headers.Add(name, new[] { value });
+        }
+
+        /// <summary>
+        /// Add header.
+        /// </summary>
+        /// <param name="name">
+        /// The name.
+        /// </param>
+        /// <param name="values">
+        /// Header values.
+        /// </param>
+        public void AddHeader(string name, string[] values)
+        {
+            Check.NotEmpty(values, nameof(values));
+
+            var newHeaderValues = Headers.TryGetValue(name, out string[] existingValues)
+                ? values.Union(existingValues).ToArray()
+                : values;
+
+            Headers[name] = newHeaderValues;
         }
     }
 }

--- a/src/WireMock.Net/ResponseMessage.cs
+++ b/src/WireMock.Net/ResponseMessage.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using WireMock.Util;
 using WireMock.Validation;
 
 namespace WireMock
@@ -14,7 +15,7 @@ namespace WireMock
         /// <summary>
         /// Gets the headers.
         /// </summary>
-        public IDictionary<string, string[]> Headers { get; set; } = new ConcurrentDictionary<string, string[]>();
+        public IDictionary<string, WireMockList<string>> Headers { get; set; } = new ConcurrentDictionary<string, WireMockList<string>>();
 
         /// <summary>
         /// Gets or sets the status code.
@@ -57,37 +58,29 @@ namespace WireMock
         public Encoding BodyEncoding { get; set; } = new UTF8Encoding(false);
 
         /// <summary>
-        /// Add header.
+        /// Adds the header.
         /// </summary>
-        /// <param name="name">
-        /// The name.
-        /// </param>
-        /// <param name="value">
-        /// The value.
-        /// </param>
+        /// <param name="name">The name.</param>
+        /// <param name="value">The value.</param>
         public void AddHeader(string name, string value)
         {
-            Headers.Add(name, new[] { value });
+            Headers.Add(name, new WireMockList<string>(value));
         }
 
         /// <summary>
-        /// Add header.
+        /// Adds the header.
         /// </summary>
-        /// <param name="name">
-        /// The name.
-        /// </param>
-        /// <param name="values">
-        /// Header values.
-        /// </param>
-        public void AddHeader(string name, string[] values)
+        /// <param name="name">The name.</param>
+        /// <param name="values">The values.</param>
+        public void AddHeader(string name, params string[] values)
         {
             Check.NotEmpty(values, nameof(values));
 
-            var newHeaderValues = Headers.TryGetValue(name, out string[] existingValues)
+            var newHeaderValues = Headers.TryGetValue(name, out WireMockList<string> existingValues)
                 ? values.Union(existingValues).ToArray()
                 : values;
 
-            Headers[name] = newHeaderValues;
+            Headers[name] = new WireMockList<string>(newHeaderValues);
         }
     }
 }

--- a/src/WireMock.Net/Serialization/MappingConverter.cs
+++ b/src/WireMock.Net/Serialization/MappingConverter.cs
@@ -108,7 +108,7 @@ namespace WireMock.Serialization
             {
                 mappingModel.Response.BodyDestination = response.ResponseMessage.BodyDestination;
                 mappingModel.Response.StatusCode = response.ResponseMessage.StatusCode;
-                mappingModel.Response.Headers = response.ResponseMessage.Headers;
+                mappingModel.Response.Headers = response.ResponseMessage.Headers.ToDictionary(header => header.Key, header => header.Value[0]);
                 mappingModel.Response.Body = response.ResponseMessage.Body;
                 mappingModel.Response.BodyAsBytes = response.ResponseMessage.BodyAsBytes;
                 mappingModel.Response.BodyAsFile = response.ResponseMessage.BodyAsFile;

--- a/src/WireMock.Net/Serialization/MappingConverter.cs
+++ b/src/WireMock.Net/Serialization/MappingConverter.cs
@@ -8,6 +8,7 @@ using WireMock.Matchers;
 using WireMock.Matchers.Request;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
+using WireMock.Util;
 
 namespace WireMock.Serialization
 {
@@ -108,7 +109,7 @@ namespace WireMock.Serialization
             {
                 mappingModel.Response.BodyDestination = response.ResponseMessage.BodyDestination;
                 mappingModel.Response.StatusCode = response.ResponseMessage.StatusCode;
-                mappingModel.Response.Headers = response.ResponseMessage.Headers.ToDictionary(header => header.Key, header => header.Value[0]);
+                mappingModel.Response.Headers = Map(response.ResponseMessage.Headers);
                 mappingModel.Response.Body = response.ResponseMessage.Body;
                 mappingModel.Response.BodyAsBytes = response.ResponseMessage.BodyAsBytes;
                 mappingModel.Response.BodyAsFile = response.ResponseMessage.BodyAsFile;
@@ -127,7 +128,24 @@ namespace WireMock.Serialization
             return mappingModel;
         }
 
-        public static MatcherModel[] Map([CanBeNull] IEnumerable<IMatcher> matchers)
+        private static IDictionary<string, object> Map(IDictionary<string, WireMockList<string>> dictionary)
+        {
+            if (dictionary == null)
+            {
+                return null;
+            }
+
+            var newDictionary = new Dictionary<string, object>();
+            foreach (var entry in dictionary)
+            {
+                object value = entry.Value.Count == 1 ? (object)entry.Value.ToString() : entry.Value;
+                newDictionary.Add(entry.Key, value);
+            }
+
+            return newDictionary;
+        }
+
+        private static MatcherModel[] Map([CanBeNull] IEnumerable<IMatcher> matchers)
         {
             if (matchers == null || !matchers.Any())
                 return null;
@@ -135,7 +153,7 @@ namespace WireMock.Serialization
             return matchers.Select(Map).Where(x => x != null).ToArray();
         }
 
-        public static MatcherModel Map([CanBeNull] IMatcher matcher)
+        private static MatcherModel Map([CanBeNull] IMatcher matcher)
         {
             if (matcher == null)
                 return null;
@@ -150,7 +168,7 @@ namespace WireMock.Serialization
             };
         }
 
-        public static string[] Map<T>([CanBeNull] IEnumerable<Func<T, bool>> funcs)
+        private static string[] Map<T>([CanBeNull] IEnumerable<Func<T, bool>> funcs)
         {
             if (funcs == null || !funcs.Any())
                 return null;
@@ -158,7 +176,7 @@ namespace WireMock.Serialization
             return funcs.Select(Map).Where(x => x != null).ToArray();
         }
 
-        public static string Map<T>([CanBeNull] Func<T, bool> func)
+        private static string Map<T>([CanBeNull] Func<T, bool> func)
         {
             return func?.ToString();
         }

--- a/src/WireMock.Net/Server/FluentMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.Admin.cs
@@ -519,12 +519,15 @@ namespace WireMock.Server
             {
                 string path = requestModel.Path as string;
                 if (path != null)
+                {
                     requestBuilder = requestBuilder.WithPath(path);
+                }
                 else
                 {
                     var pathModel = JsonUtils.ParseJTokenToObject<PathModel>(requestModel.Path);
                     if (pathModel?.Matchers != null)
-                        requestBuilder = requestBuilder.WithPath(pathModel.Matchers.Select(MappingConverter.Map).ToArray());
+                        requestBuilder =
+                            requestBuilder.WithPath(pathModel.Matchers.Select(MappingConverter.Map).ToArray());
                 }
             }
 
@@ -532,17 +535,22 @@ namespace WireMock.Server
             {
                 string url = requestModel.Url as string;
                 if (url != null)
+                {
                     requestBuilder = requestBuilder.WithUrl(url);
+                }
                 else
                 {
                     var urlModel = JsonUtils.ParseJTokenToObject<UrlModel>(requestModel.Url);
                     if (urlModel?.Matchers != null)
-                        requestBuilder = requestBuilder.WithUrl(urlModel.Matchers.Select(MappingConverter.Map).ToArray());
+                        requestBuilder =
+                            requestBuilder.WithUrl(urlModel.Matchers.Select(MappingConverter.Map).ToArray());
                 }
             }
 
             if (requestModel.Methods != null)
+            {
                 requestBuilder = requestBuilder.UsingVerb(requestModel.Methods);
+            }
 
             if (requestModel.Headers != null)
             {
@@ -603,7 +611,12 @@ namespace WireMock.Server
 
             if (responseModel.Headers != null)
             {
-                responseBuilder = responseBuilder.WithHeaders(responseModel.Headers);
+                foreach (var entry in responseModel.Headers)
+                {
+                    responseBuilder = entry.Value is string value ?
+                        responseBuilder.WithHeader(entry.Key, value) :
+                        responseBuilder.WithHeader(entry.Key, JsonUtils.ParseJTokenToObject<string[]>(entry.Value));
+                }
             }
             else if (responseModel.HeadersRaw != null)
             {
@@ -647,7 +660,7 @@ namespace WireMock.Server
             {
                 Body = JsonConvert.SerializeObject(result, _settings),
                 StatusCode = 200,
-                Headers = new Dictionary<string, string[]> { { "Content-Type", new[] { "application/json" } } }
+                Headers = new Dictionary<string, WireMockList<string>> { { "Content-Type", new WireMockList<string>("application/json") } }
             };
         }
 

--- a/src/WireMock.Net/Server/FluentMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.Admin.cs
@@ -3,22 +3,22 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
 using WireMock.Admin.Mappings;
 using WireMock.Admin.Requests;
 using WireMock.Admin.Settings;
+using WireMock.Http;
 using WireMock.Logging;
 using WireMock.Matchers;
 using WireMock.Matchers.Request;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
+using WireMock.Serialization;
+using WireMock.Settings;
 using WireMock.Util;
 using WireMock.Validation;
-using WireMock.Http;
-using System.Threading.Tasks;
-using WireMock.Settings;
-using WireMock.Serialization;
 
 namespace WireMock.Server
 {
@@ -647,7 +647,7 @@ namespace WireMock.Server
             {
                 Body = JsonConvert.SerializeObject(result, _settings),
                 StatusCode = 200,
-                Headers = new Dictionary<string, string> { { "Content-Type", "application/json" } }
+                Headers = new Dictionary<string, string[]> { { "Content-Type", new[] { "application/json" } } }
             };
         }
 

--- a/src/WireMock.Net/Transformers/ResponseMessageTransformer.cs
+++ b/src/WireMock.Net/Transformers/ResponseMessageTransformer.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using HandlebarsDotNet;
+using WireMock.Util;
 
 namespace WireMock.Transformers
 {
@@ -17,7 +18,7 @@ namespace WireMock.Transformers
             responseMessage.Body = templateBody(template);
 
             // Headers
-            var newHeaders = new Dictionary<string, string[]>();
+            var newHeaders = new Dictionary<string, WireMockList<string>>();
             foreach (var header in original.Headers)
             {
                 var templateHeaderKey = Handlebars.Compile(header.Key);
@@ -26,7 +27,7 @@ namespace WireMock.Transformers
                     .Select(func => func(template))
                     .ToArray();
 
-                newHeaders.Add(templateHeaderKey(template), templateHeaderValues);
+                newHeaders.Add(templateHeaderKey(template), new WireMockList<string>(templateHeaderValues));
             }
 
             responseMessage.Headers = newHeaders;

--- a/src/WireMock.Net/Transformers/ResponseMessageTransformer.cs
+++ b/src/WireMock.Net/Transformers/ResponseMessageTransformer.cs
@@ -1,5 +1,6 @@
-﻿using HandlebarsDotNet;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
+using HandlebarsDotNet;
 
 namespace WireMock.Transformers
 {
@@ -16,13 +17,16 @@ namespace WireMock.Transformers
             responseMessage.Body = templateBody(template);
 
             // Headers
-            var newHeaders = new Dictionary<string, string>();
+            var newHeaders = new Dictionary<string, string[]>();
             foreach (var header in original.Headers)
             {
                 var templateHeaderKey = Handlebars.Compile(header.Key);
-                var templateHeaderValue = Handlebars.Compile(header.Value);
+                var templateHeaderValues = header.Value
+                    .Select(Handlebars.Compile)
+                    .Select(func => func(template))
+                    .ToArray();
 
-                newHeaders.Add(templateHeaderKey(template), templateHeaderValue(template));
+                newHeaders.Add(templateHeaderKey(template), templateHeaderValues);
             }
 
             responseMessage.Headers = newHeaders;

--- a/src/WireMock.Net/Util/JsonUtils.cs
+++ b/src/WireMock.Net/Util/JsonUtils.cs
@@ -7,13 +7,12 @@ namespace WireMock.Util
         public static T ParseJTokenToObject<T>(object value)
         {
             if (value == null)
+            {
                 return default(T);
+            }
 
-            JToken token = value as JToken;
-            if (token == null)
-                return default(T);
-
-            return token.ToObject<T>();
+            var token = value as JToken;
+            return token == null ? default(T) : token.ToObject<T>();
         }
     }
 }

--- a/src/WireMock.Net/Util/WireMockList.cs
+++ b/src/WireMock.Net/Util/WireMockList.cs
@@ -36,9 +36,6 @@ namespace WireMock.Util
         /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
-        /// <returns>
-        /// A <see cref="string" /> that represents this instance.
-        /// </returns>
         public override string ToString()
         {
             if (this != null && this.Any())

--- a/test/WireMock.Net.Tests/RequestMessageTests.cs
+++ b/test/WireMock.Net.Tests/RequestMessageTests.cs
@@ -8,13 +8,13 @@ namespace WireMock.Net.Tests
     //[TestFixture]
     public class RequestMessageTests
     {
-        private const string clientIP = "::1";
+        private const string ClientIp = "::1";
 
         [Fact]
         public void Should_handle_empty_query()
         {
             // given
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp);
 
             // then
             Check.That(request.GetParameter("not_there")).IsNull();
@@ -26,7 +26,7 @@ namespace WireMock.Net.Tests
             // given
             string bodyAsString = "whatever";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost?foo=bar&multi=1&multi=2"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost?foo=bar&multi=1&multi=2"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             Check.That(request.GetParameter("foo")).Contains("bar");

--- a/test/WireMock.Net.Tests/RequestTests.ClientIP.cs
+++ b/test/WireMock.Net.Tests/RequestTests.ClientIP.cs
@@ -1,4 +1,3 @@
-
 using System;
 using NFluent;
 using WireMock.Matchers.Request;

--- a/test/WireMock.Net.Tests/RequestTests.cs
+++ b/test/WireMock.Net.Tests/RequestTests.cs
@@ -12,7 +12,7 @@ namespace WireMock.Net.Tests
     //[TestFixture]
     public partial class RequestTests
     {
-        private const string clientIP = "::1";
+        private const string ClientIp = "::1";
 
         [Fact]
         public void Should_specify_requests_matching_given_path()
@@ -21,7 +21,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath("/foo");
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "blabla", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "blabla", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -33,8 +33,8 @@ namespace WireMock.Net.Tests
         {
             var requestBuilder = Request.Create().WithPath("/x1", "/x2");
 
-            var request1 = new RequestMessage(new Uri("http://localhost/x1"), "blabla", clientIP);
-            var request2 = new RequestMessage(new Uri("http://localhost/x2"), "blabla", clientIP);
+            var request1 = new RequestMessage(new Uri("http://localhost/x1"), "blabla", ClientIp);
+            var request2 = new RequestMessage(new Uri("http://localhost/x2"), "blabla", ClientIp);
 
             var requestMatchResult = new RequestMatchResult();
             Check.That(requestBuilder.GetMatchingScore(request1, requestMatchResult)).IsEqualTo(1.0);
@@ -48,7 +48,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath(url => url.EndsWith("/foo"));
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "blabla", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "blabla", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -62,7 +62,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath(new RegexMatcher("^/foo"));
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo/bar"), "blabla", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo/bar"), "blabla", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -76,7 +76,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath("/foo");
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/bar"), "blabla", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/bar"), "blabla", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -90,7 +90,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithUrl("*/foo");
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "blabla", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "blabla", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -104,7 +104,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath("/foo").UsingPut();
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -118,7 +118,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath("/foo").UsingPost();
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -132,7 +132,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath("/foo").UsingGet();
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "GET", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "GET", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -148,7 +148,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "whatever";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "Delete", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "Delete", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -162,7 +162,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath("/foo").UsingHead();
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "HEAD", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "HEAD", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -176,7 +176,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath("/foo").UsingPut();
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "HEAD", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "HEAD", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -190,7 +190,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithPath("/bar").UsingPut();
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -206,7 +206,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "whatever";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string> { { "X-toto", "tata" } });
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string[]> { { "X-toto", new [] { "tata" } } });
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -222,7 +222,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "whatever";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string> { { "X-toto", "tata" } });
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string[]> { { "X-toto", new[] { "tata" } } });
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -238,7 +238,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "whatever";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string> { { "X-toto", "ABC" } });
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string[]> { { "X-toto", new[] { "ABC" } } });
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -254,7 +254,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "whatever";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string> { { "X-toto", "TaTa" } });
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string[]> { { "X-toto", new[] { "TaTa" } } });
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -268,7 +268,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().UsingAnyVerb().WithCookie("session", "a*");
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, null, null, null, null, new Dictionary<string, string> { { "session", "abc" } });
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, null, null, null, null, new Dictionary<string, string> { { "session", "abc" } });
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -284,7 +284,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "Hello world!";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -300,7 +300,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "cat";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -316,7 +316,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "cat";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -332,7 +332,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "caR";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -348,7 +348,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "The car drives in the street.";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -364,7 +364,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "Hello";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -380,7 +380,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "Hello world!";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string> { { "X-toto", "tatata" } });
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string[]> { { "X-toto", new[] { "tatata" } } });
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -396,7 +396,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "Hello world!";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -417,7 +417,7 @@ namespace WireMock.Net.Tests
                         <todo-item id='a3'>xyz</todo-item>
                     </todo-list>";
             byte[] body = Encoding.UTF8.GetBytes(xmlBodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, xmlBodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, xmlBodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -438,7 +438,7 @@ namespace WireMock.Net.Tests
                         <todo-item id='a3'>xyz</todo-item>
                     </todo-list>";
             byte[] body = Encoding.UTF8.GetBytes(xmlBodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, xmlBodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, xmlBodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -454,7 +454,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "{ \"things\": [ { \"name\": \"RequiredThing\" }, { \"name\": \"Wiremock\" } ] }";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -470,7 +470,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "{ \"things\": { \"name\": \"Wiremock\" } }";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -486,7 +486,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "xxx";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", clientIP, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string> { { "X-toto", "tatata" } });
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string[]> { { "X-toto", new[] { "tata" } } });
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -500,7 +500,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithParam("bar", "1", "2");
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo?bar=1&bar=2"), "PUT", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo?bar=1&bar=2"), "PUT", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -514,7 +514,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithParam("bar");
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo?bar"), "PUT", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo?bar"), "PUT", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -528,7 +528,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().UsingAnyVerb().WithParam(p => p.ContainsKey("bar"));
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/foo?bar=1&bar=2"), "PUT", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/foo?bar=1&bar=2"), "PUT", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();
@@ -542,7 +542,7 @@ namespace WireMock.Net.Tests
             var spec = Request.Create().WithParam("bar", "1");
 
             // when
-            var request = new RequestMessage(new Uri("http://localhost/test=7"), "PUT", clientIP);
+            var request = new RequestMessage(new Uri("http://localhost/test=7"), "PUT", ClientIp);
 
             // then
             var requestMatchResult = new RequestMatchResult();

--- a/test/WireMock.Net.Tests/ResponseTests.cs
+++ b/test/WireMock.Net.Tests/ResponseTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using NFluent;
@@ -8,67 +7,9 @@ using Xunit;
 
 namespace WireMock.Net.Tests
 {
-    //[TestFixture]
-    public class ResponseTests
+    public partial class ResponseTests
     {
-        private const string clientIP = "::1";
-
-        [Fact]
-        public async Task Response_ProvideResponse_Handlebars_UrlPathVerb()
-        {
-            // given
-            string bodyAsString = "abc";
-            byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
-
-            var response = Response.Create()
-                .WithBody("test {{request.url}} {{request.path}} {{request.method}}")
-                .WithTransformer();
-
-            // act
-            var responseMessage = await response.ProvideResponseAsync(request);
-
-            // then
-            Check.That(responseMessage.Body).Equals("test http://localhost/foo /foo post");
-        }
-
-        [Fact]
-        public async Task Response_ProvideResponse_Handlebars_Query()
-        {
-            // given
-            string bodyAsString = "abc";
-            byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo?a=1&a=2&b=5"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
-
-            var response = Response.Create()
-                .WithBody("test keya={{request.query.a}} idx={{request.query.a.[0]}} idx={{request.query.a.[1]}} keyb={{request.query.b}}")
-                .WithTransformer();
-
-            // act
-            var responseMessage = await response.ProvideResponseAsync(request);
-
-            // then
-            Check.That(responseMessage.Body).Equals("test keya=1 idx=1 idx=2 keyb=5");
-        }
-
-        [Fact]
-        public async Task Response_ProvideResponse_Handlebars_Headers()
-        {
-            // given
-            string bodyAsString = "abc";
-            byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string> { { "Content-Type", "text/plain" } });
-
-            var response = Response.Create().WithHeader("x", "{{request.headers.Content-Type}}").WithBody("test").WithTransformer();
-
-            // act
-            var responseMessage = await response.ProvideResponseAsync(request);
-
-            // then
-            Check.That(responseMessage.Body).Equals("test");
-            Check.That(responseMessage.Headers).ContainsKey("x");
-            Check.That(responseMessage.Headers["x"]).ContainsExactly("text/plain");
-        }
+        private const string ClientIp = "::1";
 
         [Fact]
         public async Task Response_ProvideResponse_WithBody_Bytes_Encoding_Destination_String()
@@ -76,7 +17,7 @@ namespace WireMock.Net.Tests
             // given
             string bodyAsString = "abc";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             var response = Response.Create().WithBody(new byte[] { 48, 49 }, BodyDestinationFormat.String, Encoding.ASCII);
 
@@ -95,7 +36,7 @@ namespace WireMock.Net.Tests
             // given
             string bodyAsString = "abc";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             var response = Response.Create().WithBody(new byte[] { 48, 49 }, BodyDestinationFormat.SameAsSource, Encoding.ASCII);
 
@@ -114,7 +55,7 @@ namespace WireMock.Net.Tests
             // given
             string bodyAsString = "abc";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             var response = Response.Create().WithBody("test", null, Encoding.ASCII);
 
@@ -132,7 +73,7 @@ namespace WireMock.Net.Tests
             // given
             string bodyAsString = "abc";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", clientIP, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             var response = Response.Create().WithBodyAsJson(new { value = "test" }, Encoding.ASCII);
 

--- a/test/WireMock.Net.Tests/ResponseTests.cs
+++ b/test/WireMock.Net.Tests/ResponseTests.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using NFluent;
-using Xunit;
 using WireMock.ResponseBuilders;
+using Xunit;
 
 namespace WireMock.Net.Tests
 {
@@ -66,7 +66,8 @@ namespace WireMock.Net.Tests
 
             // then
             Check.That(responseMessage.Body).Equals("test");
-            Check.That(responseMessage.Headers).Contains(new KeyValuePair<string, string>("x", "text/plain"));
+            Check.That(responseMessage.Headers).ContainsKey("x");
+            Check.That(responseMessage.Headers["x"]).ContainsExactly("text/plain");
         }
 
         [Fact]

--- a/test/WireMock.Net.Tests/StatefulBehaviorTests.cs
+++ b/test/WireMock.Net.Tests/StatefulBehaviorTests.cs
@@ -7,7 +7,6 @@ using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace WireMock.Net.Tests
 {


### PR DESCRIPTION
Add ability to specify several values for same header in response. In this PR it is not supported to define in json.

WithHeader and WithHeaders methods are backward-compatible. The only change, that could be breaking - public property Headers in ResponseMessage has different type now