### PR TITLE
Add the Host, Protocol, Port and Origin to the Request message so they can be used in templating

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,6 +39,6 @@ test_script:
   - nuget.exe install coveralls.net -ExcludeVersion
   - pip install codecov
 
-  - cmd: '"OpenCover\tools\OpenCover.Console.exe" -register:user -target:dotnet.exe -targetargs:"test test\WireMock.Net.Tests\WireMock.Net.Tests.csproj --no-build" -returntargetcode -filter:"+[WireMock.Net]* -[WireMock.Net.Tests*]*" -output:coverage.xml -oldstyle -searchdirs:".\test\WireMock.Net.Tests\bin\%CONFIGURATION%\net452"'
+  - cmd: '"OpenCover\tools\OpenCover.Console.exe" -target:dotnet.exe -targetargs:"test test\WireMock.Net.Tests\WireMock.Net.Tests.csproj --no-build" -output:coverage.xml -returntargetcode -register:user -filter:"+[WireMock.Net]* -[WireMock.Net.Tests*]*" -nodefaultfilters -returntargetcode -oldstyle'
   - codecov -f "coverage.xml"
   - coveralls.net\tools\csmacnz.Coveralls.exe --opencover -i .\coverage.xml

--- a/src/WireMock.Net/RequestMessage.cs
+++ b/src/WireMock.Net/RequestMessage.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Sockets;
 using JetBrains.Annotations;
 using WireMock.Util;
 using WireMock.Validation;
 using System.Text;
+using WireMock.Http;
 
 namespace WireMock
 {
@@ -64,6 +66,26 @@ namespace WireMock
         public string Body { get; }
 
         /// <summary>
+        /// Gets the Host
+        /// </summary>
+        public string Host { get; }
+
+        /// <summary>
+        /// Gets the protocol
+        /// </summary>
+        public string Protocol { get; }
+
+        /// <summary>
+        /// Gets the port
+        /// </summary>
+        public int Port { get; }
+
+        /// <summary>
+        /// Gets the origin
+        /// </summary>
+        public string Origin { get; }
+
+        /// <summary>
         /// Gets the body encoding.
         /// </summary>
         public Encoding BodyEncoding { get; }
@@ -86,6 +108,10 @@ namespace WireMock
             Check.NotNull(clientIP, nameof(clientIP));
 
             Url = url.ToString();
+            Origin = string.Format("{0}://{1}:{2}", url.Scheme, url.Host, url.Port);
+            Port = url.Port;
+            Protocol = url.Scheme;
+            Host = url.Host;
             Path = url.AbsolutePath;
             Method = method.ToLower();
             ClientIP = clientIP;

--- a/src/WireMock.Net/RequestMessage.cs
+++ b/src/WireMock.Net/RequestMessage.cs
@@ -1,12 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Sockets;
 using JetBrains.Annotations;
 using WireMock.Util;
 using WireMock.Validation;
 using System.Text;
-using WireMock.Http;
 
 namespace WireMock
 {
@@ -108,10 +106,10 @@ namespace WireMock
             Check.NotNull(clientIP, nameof(clientIP));
 
             Url = url.ToString();
-            Origin = string.Format("{0}://{1}:{2}", url.Scheme, url.Host, url.Port);
-            Port = url.Port;
             Protocol = url.Scheme;
             Host = url.Host;
+            Port = url.Port;
+            Origin = $"{url.Scheme}://{url.Host}:{url.Port}";
             Path = url.AbsolutePath;
             Method = method.ToLower();
             ClientIP = clientIP;

--- a/test/WireMock.Net.Tests/ResponseTests.Handlebars.cs
+++ b/test/WireMock.Net.Tests/ResponseTests.Handlebars.cs
@@ -93,7 +93,7 @@ namespace WireMock.Net.Tests
             // given
             string bodyAsString = "abc";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost:1234/foo?a=b"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
+            var request = new RequestMessage(new Uri("http://localhost:1234"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
 
             var response = Response.Create()
                 .WithBody("test {{request.origin}} {{request.port}} {{request.protocol}} {{request.host}}")

--- a/test/WireMock.Net.Tests/ResponseTests.Handlebars.cs
+++ b/test/WireMock.Net.Tests/ResponseTests.Handlebars.cs
@@ -86,5 +86,24 @@ namespace WireMock.Net.Tests
             Check.That(responseMessage.Headers["x"]).Contains("text/plain");
             Check.That(responseMessage.Headers["x"]).Contains("http://localhost/foo");
         }
+
+        [Fact]
+        public async Task Response_ProvideResponse_Handlebars_Origin_Port_Protocol_Host()
+        {
+            // given
+            string bodyAsString = "abc";
+            byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
+            var request = new RequestMessage(new Uri("http://localhost:1234/foo?a=b"), "POST", ClientIp, body, bodyAsString, Encoding.UTF8);
+
+            var response = Response.Create()
+                .WithBody("test {{request.origin}} {{request.port}} {{request.protocol}} {{request.host}}")
+                .WithTransformer();
+
+            // act
+            var responseMessage = await response.ProvideResponseAsync(request);
+
+            // then
+            Check.That(responseMessage.Body).Equals("test http://localhost:1234 1234 http localhost");
+        }
     }
 }


### PR DESCRIPTION
Hi

I needed to be able to template responses based on more granular information than was already available in the request object so have added some calculated fields and supporting test. Would you be interested in accepting it back?

- Add new fields for Host, Origin, protocol and Port during request message creation, derived from the Uri object
- Allow the new fields to be accessed in the templating engine
- Add tests for the new fields