### PR TITLE
Fix issue with concurrent logging

### DIFF
--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
@@ -46,6 +46,7 @@ namespace WireMock.Owin
             _host = new WebHostBuilder()
                 .Configure(appBuilder =>
                 {
+                    appBuilder.UseMiddleware<GlobalExceptionMiddleware>();
                     _options.PreWireMockMiddlewareInit?.Invoke(appBuilder);
                     appBuilder.UseMiddleware<WireMockMiddleware>(_options);
                     _options.PostWireMockMiddlewareInit?.Invoke(appBuilder);

--- a/src/WireMock.Net/Owin/GlobalExceptionMiddleware.cs
+++ b/src/WireMock.Net/Owin/GlobalExceptionMiddleware.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+#if !NETSTANDARD
+using Microsoft.Owin;
+#else
+using Microsoft.AspNetCore.Http;
+#endif
+
+namespace WireMock.Owin
+{
+#if !NETSTANDARD
+    internal class GlobalExceptionMiddleware : OwinMiddleware
+#else
+    internal class GlobalExceptionMiddleware
+#endif
+    {
+#if !NETSTANDARD
+        public GlobalExceptionMiddleware(OwinMiddleware next) : base(next) { }
+#else
+        public GlobalExceptionMiddleware(RequestDelegate next)
+        {
+            Next = next;
+        }
+#endif
+
+#if NETSTANDARD
+    public RequestDelegate Next { get; private set; }
+#endif
+
+    private readonly OwinResponseMapper _responseMapper = new OwinResponseMapper();
+
+#if !NETSTANDARD
+        public override async Task Invoke(IOwinContext ctx)
+#else
+        public async Task Invoke(HttpContext ctx)
+#endif
+        {
+            try
+            {
+                await Next?.Invoke(ctx);
+            }
+            catch (Exception ex)
+            {
+                await _responseMapper.MapAsync(new ResponseMessage { StatusCode = 500, Body = JsonConvert.SerializeObject(ex) }, ctx.Response);
+            }
+        }
+    }
+}

--- a/src/WireMock.Net/Owin/OwinSelfHost.cs
+++ b/src/WireMock.Net/Owin/OwinSelfHost.cs
@@ -61,6 +61,7 @@ namespace WireMock.Owin
 
             Action<IAppBuilder> startup = app =>
             {
+                app.Use<GlobalExceptionMiddleware>();
                 _options.PreWireMockMiddlewareInit?.Invoke(app);
                 app.Use<WireMockMiddleware>(_options);
                 _options.PostWireMockMiddlewareInit?.Invoke(app);

--- a/src/WireMock.Net/Owin/WireMockMiddleware.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddleware.cs
@@ -5,6 +5,7 @@ using WireMock.Matchers.Request;
 using System.Linq;
 using WireMock.Matchers;
 using WireMock.Util;
+using Newtonsoft.Json;
 #if !NETSTANDARD
 using Microsoft.Owin;
 #else
@@ -124,7 +125,7 @@ namespace WireMock.Owin
             }
             catch (Exception ex)
             {
-                response = new ResponseMessage { StatusCode = 500, Body = ex.ToString() };
+                response = new ResponseMessage { StatusCode = 500, Body = JsonConvert.SerializeObject(ex) };
             }
             finally
             {

--- a/src/WireMock.Net/Owin/WireMockMiddlewareOptions.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddlewareOptions.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using WireMock.Logging;
 using WireMock.Matchers;
+using WireMock.Utils;
 #if !NETSTANDARD
 using Owin;
 #else
@@ -22,7 +23,7 @@ namespace WireMock.Owin
 
         public IList<Mapping> Mappings { get; set; } = new List<Mapping>();
 
-        public ObservableCollection<LogEntry> LogEntries { get; } = new ObservableCollection<LogEntry>();
+        public ObservableCollection<LogEntry> LogEntries { get; } = new ConcurentObservableCollection<LogEntry>();
 
         public int? RequestLogExpirationDuration { get; set; }
 

--- a/src/WireMock.Net/Owin/WireMockMiddlewareOptions.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddlewareOptions.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using WireMock.Logging;
 using WireMock.Matchers;
-using WireMock.Utils;
+using WireMock.Util;
 #if !NETSTANDARD
 using Owin;
 #else

--- a/src/WireMock.Net/Util/ConcurentObservableCollection.cs
+++ b/src/WireMock.Net/Util/ConcurentObservableCollection.cs
@@ -1,21 +1,21 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
-namespace WireMock.Utils
+namespace WireMock.Util
 {
     /// <summary>
     /// A special Collection that overrides methods of <see cref="ObservableCollection{T}"/> to make them thread safe
     /// </summary>
-    /// <typeparam name="T">The generic type</typeparam>
-    /// <seealso cref="ObservableCollection{T}" />
+    /// <typeparam name="T">The type of elements in the collection.</typeparam>
+    /// <inheritdoc cref="ObservableCollection{T}" />
     public class ConcurentObservableCollection<T> : ObservableCollection<T>
     {
         private readonly object _lockObject = new object();
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConcurentObservableCollection{T}"/> class.
-        /// </summary>
-        public ConcurentObservableCollection() : base() { }
+        /// <summary> 
+        /// Initializes a new instance of the <see cref="T:WireMock.Util.ConcurentObservableCollection`1" /> class. 
+        /// </summary> 
+        public ConcurentObservableCollection() { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConcurentObservableCollection{T}"/> class that contains elements copied from the specified list.
@@ -29,9 +29,7 @@ namespace WireMock.Utils
         /// <param name="collection">The collection from which the elements are copied.</param>
         public ConcurentObservableCollection(IEnumerable<T> collection) : base(collection) { }
 
-        /// <summary>
-        /// Removes all items from the collection.
-        /// </summary>
+        /// <inheritdoc cref="ObservableCollection{T}.ClearItems"/>
         protected override void ClearItems()
         {
             lock (_lockObject)
@@ -40,10 +38,7 @@ namespace WireMock.Utils
             }
         }
 
-        /// <summary>
-        /// Removes the item at the specified index of the collection.
-        /// </summary>
-        /// <param name="index">The zero-based index of the element to remove.</param>
+        /// <inheritdoc cref="ObservableCollection{T}.RemoveItem"/>
         protected override void RemoveItem(int index)
         {
             lock (_lockObject)
@@ -52,11 +47,7 @@ namespace WireMock.Utils
             }
         }
 
-        /// <summary>
-        /// Inserts an item into the collection at the specified index.
-        /// </summary>
-        /// <param name="index">The zero-based index at which item should be inserted.</param>
-        /// <param name="item">The object to insert.</param>
+        /// <inheritdoc cref="ObservableCollection{T}.InsertItem"/>
         protected override void InsertItem(int index, T item)
         {
             lock (_lockObject)
@@ -65,11 +56,7 @@ namespace WireMock.Utils
             }
         }
 
-        /// <summary>
-        /// Replaces the element at the specified index.
-        /// </summary>
-        /// <param name="index">The zero-based index of the element to replace.</param>
-        /// <param name="item">The new value for the element at the specified index.</param>
+        /// <inheritdoc cref="ObservableCollection{T}.SetItem"/>
         protected override void SetItem(int index, T item)
         {
             lock (_lockObject)
@@ -78,11 +65,7 @@ namespace WireMock.Utils
             }
         }
 
-        /// <summary>
-        /// Moves the item at the specified index to a new location in the collection.
-        /// </summary>
-        /// <param name="oldIndex">The zero-based index specifying the location of the item to be moved.</param>
-        /// <param name="newIndex">The zero-based index specifying the new location of the item.</param>
+        /// <inheritdoc cref="ObservableCollection{T}.MoveItem"/>
         protected override void MoveItem(int oldIndex, int newIndex)
         {
             lock (_lockObject)

--- a/src/WireMock.Net/Util/ConcurentObservableCollection.cs
+++ b/src/WireMock.Net/Util/ConcurentObservableCollection.cs
@@ -1,0 +1,94 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace WireMock.Utils
+{
+    /// <summary>
+    /// A special Collection that overrides methods of <see cref="ObservableCollection{T}"/> to make them thread safe
+    /// </summary>
+    /// <typeparam name="T">The generic type</typeparam>
+    /// <seealso cref="ObservableCollection{T}" />
+    public class ConcurentObservableCollection<T> : ObservableCollection<T>
+    {
+        private readonly object _lockObject = new object();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConcurentObservableCollection{T}"/> class.
+        /// </summary>
+        public ConcurentObservableCollection() : base() { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConcurentObservableCollection{T}"/> class that contains elements copied from the specified list.
+        /// </summary>
+        /// <param name="list">The list from which the elements are copied.</param>
+        public ConcurentObservableCollection(List<T> list) : base(list) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConcurentObservableCollection{T}"/> class that contains elements copied from the specified collection.
+        /// </summary>
+        /// <param name="collection">The collection from which the elements are copied.</param>
+        public ConcurentObservableCollection(IEnumerable<T> collection) : base(collection) { }
+
+        /// <summary>
+        /// Removes all items from the collection.
+        /// </summary>
+        protected override void ClearItems()
+        {
+            lock (_lockObject)
+            {
+                base.ClearItems();
+            }
+        }
+
+        /// <summary>
+        /// Removes the item at the specified index of the collection.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to remove.</param>
+        protected override void RemoveItem(int index)
+        {
+            lock (_lockObject)
+            {
+                base.RemoveItem(index);
+            }
+        }
+
+        /// <summary>
+        /// Inserts an item into the collection at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index at which item should be inserted.</param>
+        /// <param name="item">The object to insert.</param>
+        protected override void InsertItem(int index, T item)
+        {
+            lock (_lockObject)
+            {
+                base.InsertItem(index, item);
+            }
+        }
+
+        /// <summary>
+        /// Replaces the element at the specified index.
+        /// </summary>
+        /// <param name="index">The zero-based index of the element to replace.</param>
+        /// <param name="item">The new value for the element at the specified index.</param>
+        protected override void SetItem(int index, T item)
+        {
+            lock (_lockObject)
+            {
+                base.SetItem(index, item);
+            }
+        }
+
+        /// <summary>
+        /// Moves the item at the specified index to a new location in the collection.
+        /// </summary>
+        /// <param name="oldIndex">The zero-based index specifying the location of the item to be moved.</param>
+        /// <param name="newIndex">The zero-based index specifying the new location of the item.</param>
+        protected override void MoveItem(int oldIndex, int newIndex)
+        {
+            lock (_lockObject)
+            {
+                base.MoveItem(oldIndex, newIndex);
+            }
+        }
+    }
+}

--- a/test/WireMock.Net.Tests/ObservableLogEntriesTest.cs
+++ b/test/WireMock.Net.Tests/ObservableLogEntriesTest.cs
@@ -1,5 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
 using NFluent;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -8,7 +13,7 @@ using Xunit;
 
 namespace WireMock.Net.Tests
 {
-    public class ObservableLogEntriesTest: IDisposable
+    public class ObservableLogEntriesTest : IDisposable
     {
         private FluentMockServer _server;
 
@@ -33,6 +38,42 @@ namespace WireMock.Net.Tests
 
             // Assert
             Check.That(count).Equals(1);
+        }
+
+        [Fact]
+        public async Task ParallelTest()
+        {
+            var expectedCount = 100;
+
+            // Assign
+            _server = FluentMockServer.Start();
+
+            _server
+                .Given(Request.Create()
+                    .WithPath("/foo")
+                    .UsingGet())
+                .RespondWith(Response.Create()
+                    .WithDelay(6)
+                    .WithSuccess());
+
+            int count = 0;
+            _server.LogEntriesChanged += (sender, args) => count++;
+
+            var http = new HttpClient();
+
+            // Act
+            var listOfTasks = new List<Task<HttpResponseMessage>>();
+            for (var i = 0; i < expectedCount; i++)
+            {
+                Thread.Sleep(3);
+                listOfTasks.Add(http.GetAsync(_server.Urls[0] + $"/foo"));
+            }
+            var responses = await Task.WhenAll(listOfTasks);
+            var countResponsesWithStatusNotOk = responses.Where(r => r.StatusCode != HttpStatusCode.OK).Count();
+
+            // Assert
+            Check.That(countResponsesWithStatusNotOk).Equals(0);
+            Check.That(count).Equals(expectedCount);
         }
 
         public void Dispose()


### PR DESCRIPTION
Fixed issue with concurrent logging:
* added `ConcurrentObservableCollection` which is thread safe
* added test for checking logging with parallel requests
* added `GlobalExceptionMiddleware` that handles all exceptions that can happen in next middlewares
* changed response body from exception message to serialized exception when exception is thrown(it`s better to have whole exception fields than only exception message)