### PR TITLE
bug: Fix admin api client definition returning the wrong types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # WireMock.Net
 A C# .NET version based on [mock4net](https://github.com/alexvictoor/mock4net) which mimics the functionality from the JAVA based http://WireMock.org
 
-[![Build status](https://ci.appveyor.com/api/projects/status/b3n6q3ygbww4lyls?svg=true)](https://ci.appveyor.com/project/WireMock-Net/wiremock-net)
+[![Build status](https://ci.appveyor.com/api/projects/status/b3n6q3ygbww4lyls?svg=true)](https://ci.appveyor.com/project/StefH/wiremock-net)
 [![codecov](https://codecov.io/gh/WireMock-Net/WireMock.Net/branch/master/graph/badge.svg)](https://codecov.io/gh/WireMock-Net/WireMock.Net)
 [![Coverage Status](https://coveralls.io/repos/github/WireMock-Net/WireMock.Net/badge.svg?branch=master)](https://coveralls.io/github/WireMock-Net/WireMock.Net?branch=master)
 [![GitHub issues](https://img.shields.io/github/issues/WireMock-Net/WireMock.Net.svg)](https://github.com/WireMock-Net/WireMock.Net/issues)

--- a/src/WireMock.Net/Client/IFluentMockServerAdmin.cs
+++ b/src/WireMock.Net/Client/IFluentMockServerAdmin.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using WireMock.Admin.Mappings;
 using WireMock.Admin.Requests;
 using WireMock.Admin.Settings;
+using WireMock.Logging;
 
 namespace WireMock.Client
 {
@@ -103,7 +104,7 @@ namespace WireMock.Client
         /// </summary>
         /// <returns>LogRequestModels</returns>
         [Get("__admin/requests")]
-        Task<IList<LogRequestModel>> GetRequestsAsync();
+        Task<IList<LogEntryModel>> GetRequestsAsync();
 
         /// <summary>
         /// Delete all requests.
@@ -123,7 +124,7 @@ namespace WireMock.Client
         /// <param name="guid">The Guid</param>
         /// <returns>MappingModel</returns>
         [Get("__admin/requests/{guid}")]
-        Task<LogRequestModel> GetRequestAsync([Path] Guid guid);
+        Task<LogEntryModel> GetRequestAsync([Path] Guid guid);
 
         /// <summary>
         /// Delete a request based on the guid
@@ -137,7 +138,7 @@ namespace WireMock.Client
         /// </summary>
         /// <param name="model">The RequestModel</param>
         [Post("__admin/requests/find")]
-        Task<IList<LogRequestModel>> FindRequestsAsync([Body] RequestModel model);
+        Task<IList<LogEntryModel>> FindRequestsAsync([Body] RequestModel model);
 
         /// <summary>
         /// Get all scenarios

--- a/src/WireMock.Net/Server/FluentMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.Admin.cs
@@ -486,7 +486,7 @@ namespace WireMock.Server
                 }
             }
 
-            var result = dict.OrderBy(x => x.Value.AverageTotalScore).Select(x => x.Key);
+            var result = dict.OrderBy(x => x.Value.AverageTotalScore).Select(x => x.Key).Select(ToLogEntryModel);
 
             return ToJson(result);
         }

--- a/test/WireMock.Net.Tests/FluentMockServerAdminRestClientTests.cs
+++ b/test/WireMock.Net.Tests/FluentMockServerAdminRestClientTests.cs
@@ -22,16 +22,17 @@ namespace WireMock.Net.Tests
         private FluentMockServer _server;
 
         [Fact]
-        public async Task RestClientFindRequestsReturnsLogOfRequetsMade()
+        public async Task IFluentMockServerAdmin_FindRequestsAsync()
         {
             // given
-            _server = FluentMockServer.Start(new FluentMockServerSettings {StartAdminInterface = true});
+            _server = FluentMockServer.Start(new FluentMockServerSettings { StartAdminInterface = true });
             var serverUrl = "http://localhost:" + _server.Ports[0];
             await new HttpClient().GetAsync(serverUrl + "/foo");
             var api = RestClient.For<IFluentMockServerAdmin>(serverUrl);
 
             // when
-            var requests = await api.FindRequestsAsync(new RequestModel {Methods = new[] {"get"}});
+            var requests = await api.FindRequestsAsync(new RequestModel { Methods = new[] { "get" } });
+
             // then
             Check.That(requests).HasSize(1);
             var requestLogged = requests.First();
@@ -41,16 +42,17 @@ namespace WireMock.Net.Tests
         }
 
         [Fact]
-        public async Task RestClientGetRequestsReturnsLogOfRequetssMade()
+        public async Task IFluentMockServerAdmin_GetRequestsAsync()
         {
             // given
-            _server = FluentMockServer.Start(new FluentMockServerSettings {StartAdminInterface = true});
+            _server = FluentMockServer.Start(new FluentMockServerSettings { StartAdminInterface = true });
             var serverUrl = "http://localhost:" + _server.Ports[0];
             await new HttpClient().GetAsync(serverUrl + "/foo");
             var api = RestClient.For<IFluentMockServerAdmin>(serverUrl);
 
             // when
             var requests = await api.GetRequestsAsync();
+
             // then
             Check.That(requests).HasSize(1);
             var requestLogged = requests.First();

--- a/test/WireMock.Net.Tests/FluentMockServerAdminRestClientTests.cs
+++ b/test/WireMock.Net.Tests/FluentMockServerAdminRestClientTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using NFluent;
+using RestEase;
+using WireMock.Admin.Mappings;
+using WireMock.Client;
+using WireMock.Server;
+using WireMock.Settings;
+using Xunit;
+
+namespace WireMock.Net.Tests
+{
+    public class FluentMockServerAdminRestClientTests : IDisposable
+    {
+        public void Dispose()
+        {
+            _server?.Stop();
+        }
+
+        private FluentMockServer _server;
+
+        [Fact]
+        public async Task RestClientFindRequestsReturnsLogOfRequetsMade()
+        {
+            // given
+            _server = FluentMockServer.Start(new FluentMockServerSettings {StartAdminInterface = true});
+            var serverUrl = "http://localhost:" + _server.Ports[0];
+            await new HttpClient().GetAsync(serverUrl + "/foo");
+            var api = RestClient.For<IFluentMockServerAdmin>(serverUrl);
+
+            // when
+            var requests = await api.FindRequestsAsync(new RequestModel {Methods = new[] {"get"}});
+            // then
+            Check.That(requests).HasSize(1);
+            var requestLogged = requests.First();
+            Check.That(requestLogged.Request.Method).IsEqualTo("get");
+            Check.That(requestLogged.Request.Body).IsNull();
+            Check.That(requestLogged.Request.Path).IsEqualTo("/foo");
+        }
+
+        [Fact]
+        public async Task RestClientGetRequestsReturnsLogOfRequetssMade()
+        {
+            // given
+            _server = FluentMockServer.Start(new FluentMockServerSettings {StartAdminInterface = true});
+            var serverUrl = "http://localhost:" + _server.Ports[0];
+            await new HttpClient().GetAsync(serverUrl + "/foo");
+            var api = RestClient.For<IFluentMockServerAdmin>(serverUrl);
+
+            // when
+            var requests = await api.GetRequestsAsync();
+            // then
+            Check.That(requests).HasSize(1);
+            var requestLogged = requests.First();
+            Check.That(requestLogged.Request.Method).IsEqualTo("get");
+            Check.That(requestLogged.Request.Body).IsNull();
+            Check.That(requestLogged.Request.Path).IsEqualTo("/foo");
+        }
+    }
+}


### PR DESCRIPTION
Hello. Been testing the use of the admin api client with RestEase and noticed that the definition has the wrong types listed as being return on the get requests API meaning the restease client has null values and some data is missing. In addition the find requests API does not return LogEntryModel like the GetRequests API instead it returns LogEntry, which I have fixed so they are all the same.

- IFluentMockServerAdmin get, find and get all requests should return a log entry model
- Add tests for get and find using the rest ease api client