### PR TITLE
bug: fix supporting the Patch method and logging the body

### DIFF
--- a/src/WireMock.Net/Client/IFluentMockServerAdmin.cs
+++ b/src/WireMock.Net/Client/IFluentMockServerAdmin.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using WireMock.Admin.Mappings;
 using WireMock.Admin.Requests;
 using WireMock.Admin.Settings;
-using WireMock.Logging;
 
 namespace WireMock.Client
 {

--- a/src/WireMock.Net/Owin/OwinRequestMapper.cs
+++ b/src/WireMock.Net/Owin/OwinRequestMapper.cs
@@ -91,8 +91,9 @@ namespace WireMock.Owin
                 TRACE - Body not supported.
                 OPTIONS - Body supported but no semantics on usage (maybe in the future).
                 CONNECT - No defined body semantics
+                PATHC - Body suported
             */
-            return new[] { "PUT", "POST", "OPTIONS" }.Contains(method.ToUpper());
+            return new[] { "PUT", "POST", "OPTIONS", "PATCH" }.Contains(method.ToUpper());
         }
     }
 }

--- a/src/WireMock.Net/Owin/OwinRequestMapper.cs
+++ b/src/WireMock.Net/Owin/OwinRequestMapper.cs
@@ -91,7 +91,7 @@ namespace WireMock.Owin
                 TRACE - Body not supported.
                 OPTIONS - Body supported but no semantics on usage (maybe in the future).
                 CONNECT - No defined body semantics
-                PATHC - Body suported
+                PATCH - Body supported.
             */
             return new[] { "PUT", "POST", "OPTIONS", "PATCH" }.Contains(method.ToUpper());
         }

--- a/src/WireMock.Net/RequestBuilders/IMethodRequestBuilder.cs
+++ b/src/WireMock.Net/RequestBuilders/IMethodRequestBuilder.cs
@@ -8,12 +8,28 @@ namespace WireMock.RequestBuilders
     public interface IMethodRequestBuilder : IHeadersAndCookiesRequestBuilder
     {
         /// <summary>
+        /// The using delete.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="IRequestBuilder"/>.
+        /// </returns>
+        IRequestBuilder UsingDelete();
+
+        /// <summary>
         /// The using get.
         /// </summary>
         /// <returns>
         /// The <see cref="IRequestBuilder"/>.
         /// </returns>
         IRequestBuilder UsingGet();
+
+        /// <summary>
+        /// The using head.
+        /// </summary>
+        /// <returns>
+        /// The <see cref="IRequestBuilder"/>.
+        /// </returns>
+        IRequestBuilder UsingHead();
 
         /// <summary>
         /// The using post.
@@ -24,12 +40,12 @@ namespace WireMock.RequestBuilders
         IRequestBuilder UsingPost();
 
         /// <summary>
-        /// The using delete.
+        /// The using patch.
         /// </summary>
         /// <returns>
         /// The <see cref="IRequestBuilder"/>.
         /// </returns>
-        IRequestBuilder UsingDelete();
+        IRequestBuilder UsingPatch();
 
         /// <summary>
         /// The using put.
@@ -38,14 +54,6 @@ namespace WireMock.RequestBuilders
         /// The <see cref="IRequestBuilder"/>.
         /// </returns>
         IRequestBuilder UsingPut();
-
-        /// <summary>
-        /// The using head.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="IRequestBuilder"/>.
-        /// </returns>
-        IRequestBuilder UsingHead();
 
         /// <summary>
         /// The using any verb.

--- a/src/WireMock.Net/RequestBuilders/Request.cs
+++ b/src/WireMock.Net/RequestBuilders/Request.cs
@@ -171,70 +171,49 @@ namespace WireMock.RequestBuilders
             return this;
         }
 
-        /// <summary>
-        /// The using get.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="IRequestBuilder"/>.
-        /// </returns>
-        public IRequestBuilder UsingGet()
-        {
-            _requestMatchers.Add(new RequestMessageMethodMatcher("get"));
-            return this;
-        }
-
-        /// <summary>
-        /// The using post.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="IRequestBuilder"/>.
-        /// </returns>
-        public IRequestBuilder UsingPost()
-        {
-            _requestMatchers.Add(new RequestMessageMethodMatcher("post"));
-            return this;
-        }
-
-        /// <summary>
-        /// The using put.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="IRequestBuilder"/>.
-        /// </returns>
-        public IRequestBuilder UsingPut()
-        {
-            _requestMatchers.Add(new RequestMessageMethodMatcher("put"));
-            return this;
-        }
-
-        /// <summary>
-        /// The using delete.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="IRequestBuilder"/>.
-        /// </returns>
+        /// <inheritdoc cref="IMethodRequestBuilder.UsingDelete"/>
         public IRequestBuilder UsingDelete()
         {
             _requestMatchers.Add(new RequestMessageMethodMatcher("delete"));
             return this;
         }
 
-        /// <summary>
-        /// The using head.
-        /// </summary>
-        /// <returns>The <see cref="IRequestBuilder"/>.</returns>
+        /// <inheritdoc cref="IMethodRequestBuilder.UsingGet"/>
+        public IRequestBuilder UsingGet()
+        {
+            _requestMatchers.Add(new RequestMessageMethodMatcher("get"));
+            return this;
+        }
+
+        /// <inheritdoc cref="IMethodRequestBuilder.UsingHead"/>
         public IRequestBuilder UsingHead()
         {
             _requestMatchers.Add(new RequestMessageMethodMatcher("head"));
             return this;
         }
 
-        /// <summary>
-        /// The using any verb.
-        /// </summary>
-        /// <returns>
-        /// The <see cref="IRequestBuilder"/>.
-        /// </returns>
+        /// <inheritdoc cref="IMethodRequestBuilder.UsingPost"/>
+        public IRequestBuilder UsingPost()
+        {
+            _requestMatchers.Add(new RequestMessageMethodMatcher("post"));
+            return this;
+        }
+
+        /// <inheritdoc cref="IMethodRequestBuilder.UsingPatch"/>
+        public IRequestBuilder UsingPatch()
+        {
+            _requestMatchers.Add(new RequestMessageMethodMatcher("patch"));
+            return this;
+        }
+
+        /// <inheritdoc cref="IMethodRequestBuilder.UsingPut"/>
+        public IRequestBuilder UsingPut()
+        {
+            _requestMatchers.Add(new RequestMessageMethodMatcher("put"));
+            return this;
+        }
+
+        /// <inheritdoc cref="IMethodRequestBuilder.UsingAnyVerb"/>
         public IRequestBuilder UsingAnyVerb()
         {
             var matchers = _requestMatchers.Where(m => m is RequestMessageMethodMatcher).ToList();
@@ -246,11 +225,7 @@ namespace WireMock.RequestBuilders
             return this;
         }
 
-        /// <summary>
-        /// The using verb.
-        /// </summary>
-        /// <param name="verbs">The verbs.</param>
-        /// <returns>The <see cref="IRequestBuilder"/>.</returns>
+        /// <inheritdoc cref="IMethodRequestBuilder.UsingVerb"/>
         public IRequestBuilder UsingVerb(params string[] verbs)
         {
             Check.NotEmpty(verbs, nameof(verbs));

--- a/test/WireMock.Net.Tests/FluentMockServerTests.cs
+++ b/test/WireMock.Net.Tests/FluentMockServerTests.cs
@@ -176,6 +176,34 @@ namespace WireMock.Net.Tests
         }
 
         [Fact]
+        public async Task FluentMockServer_Should_respond_to_request_methodPatch()
+        {
+            // given
+            _server = FluentMockServer.Start();
+
+            _server.Given(Request.Create().WithPath("/foo").UsingVerb("patch"))
+                .RespondWith(Response.Create().WithBody("hello patch"));
+
+            // when
+            var msg = new HttpRequestMessage(new HttpMethod("patch"), new Uri("http://localhost:" + _server.Ports[0] + "/foo"))
+            {
+                Content = new StringContent("{\"data\": {\"attr\":\"value\"}}")
+            };
+            var response = await new HttpClient().SendAsync(msg);
+
+            // then
+            Check.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            var responseBody = await response.Content.ReadAsStringAsync();
+            Check.That(responseBody).IsEqualTo("hello patch");
+
+            Check.That(_server.LogEntries).HasSize(1);
+            var requestLogged = _server.LogEntries.First();
+            Check.That(requestLogged.RequestMessage.Method).IsEqualTo("patch");
+            Check.That(requestLogged.RequestMessage.Body).IsNotNull();
+            Check.That(requestLogged.RequestMessage.Body).IsEqualTo("{\"data\": {\"attr\":\"value\"}}");
+        }
+
+        [Fact]
         public async Task FluentMockServer_Should_respond_to_request_bodyAsString()
         {
             // given
@@ -209,35 +237,6 @@ namespace WireMock.Net.Tests
 
             // then
             Check.That(response).IsEqualTo("Hello World?");
-        }
-
-        [Fact]
-        public async Task FluentMockServer_Should_respond_to_request_methodPatch()
-        {
-            // given
-            _server = FluentMockServer.Start();
-
-            _server.Given(Request.Create().WithPath("/foo").UsingVerb("patch"))
-                   .RespondWith(Response.Create().WithBody("hello patch"));
-
-            // when
-            var msg = new HttpRequestMessage(new HttpMethod("patch"),
-                new Uri("http://localhost:" + _server.Ports[0] + "/foo"))
-            {
-                Content = new StringContent("{\"data\": {\"attr\":\"value\"}}")
-            };
-            var response = await new HttpClient().SendAsync(msg);
-
-            // then
-            Check.That(response.StatusCode).IsEqualTo(HttpStatusCode.OK);
-            var responseBody = await response.Content.ReadAsStringAsync();
-            Check.That(responseBody).IsEqualTo("hello patch");
-
-            Check.That(_server.LogEntries).HasSize(1);
-            var requestLogged = _server.LogEntries.First();
-            Check.That(requestLogged.RequestMessage.Method).IsEqualTo("patch");
-            Check.That(requestLogged.RequestMessage.Body).IsNotNull();
-            Check.That(requestLogged.RequestMessage.Body).IsEqualTo("{\"data\": {\"attr\":\"value\"}}");
         }
 
         [Fact]

--- a/test/WireMock.Net.Tests/RequestTests.PathAndMethod.cs
+++ b/test/WireMock.Net.Tests/RequestTests.PathAndMethod.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Text;
+using NFluent;
+using Xunit;
+using WireMock.RequestBuilders;
+using WireMock.Matchers.Request;
+
+namespace WireMock.Net.Tests
+{
+    //[TestFixture]
+    public partial class RequestTests
+    {
+        [Fact]
+        public void Should_specify_requests_matching_given_path_and_method_delete()
+        {
+            // given
+            var spec = Request.Create().WithPath("/foo").UsingDelete();
+
+            // when
+            string bodyAsString = "whatever";
+            byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "Delete", ClientIp, body, bodyAsString, Encoding.UTF8);
+
+            // then
+            var requestMatchResult = new RequestMatchResult();
+            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
+        }
+
+        [Fact]
+        public void Should_specify_requests_matching_given_path_and_method_get()
+        {
+            // given
+            var spec = Request.Create().WithPath("/foo").UsingGet();
+
+            // when
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "GET", ClientIp);
+
+            // then
+            var requestMatchResult = new RequestMatchResult();
+            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
+        }
+
+        [Fact]
+        public void Should_specify_requests_matching_given_path_and_method_head()
+        {
+            // given
+            var spec = Request.Create().WithPath("/foo").UsingHead();
+
+            // when
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "HEAD", ClientIp);
+
+            // then
+            var requestMatchResult = new RequestMatchResult();
+            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
+        }
+
+        [Fact]
+        public void Should_specify_requests_matching_given_path_and_method_post()
+        {
+            // given
+            var spec = Request.Create().WithPath("/foo").UsingPost();
+
+            // when
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp);
+
+            // then
+            var requestMatchResult = new RequestMatchResult();
+            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
+        }
+
+        [Fact]
+        public void Should_specify_requests_matching_given_path_and_method_put()
+        {
+            // given
+            var spec = Request.Create().WithPath("/foo").UsingPut();
+
+            // when
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp);
+
+            // then
+            var requestMatchResult = new RequestMatchResult();
+            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
+        }
+
+        [Fact]
+        public void Should_specify_requests_matching_given_path_and_method_patch()
+        {
+            // given
+            var spec = Request.Create().WithPath("/foo").UsingPatch();
+
+            // when
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PATCH", ClientIp);
+
+            // then
+            var requestMatchResult = new RequestMatchResult();
+            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
+        }
+
+        [Fact]
+        public void Should_exclude_requests_matching_given_path_but_not_http_method()
+        {
+            // given
+            var spec = Request.Create().WithPath("/foo").UsingPut();
+
+            // when
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "HEAD", ClientIp);
+
+            // then
+            var requestMatchResult = new RequestMatchResult();
+            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsNotEqualTo(1.0);
+        }
+    }
+}

--- a/test/WireMock.Net.Tests/RequestTests.cs
+++ b/test/WireMock.Net.Tests/RequestTests.cs
@@ -98,92 +98,6 @@ namespace WireMock.Net.Tests
         }
 
         [Fact]
-        public void Should_specify_requests_matching_given_path_and_method_put()
-        {
-            // given
-            var spec = Request.Create().WithPath("/foo").UsingPut();
-
-            // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp);
-
-            // then
-            var requestMatchResult = new RequestMatchResult();
-            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
-        }
-
-        [Fact]
-        public void Should_specify_requests_matching_given_path_and_method_post()
-        {
-            // given
-            var spec = Request.Create().WithPath("/foo").UsingPost();
-
-            // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "POST", ClientIp);
-
-            // then
-            var requestMatchResult = new RequestMatchResult();
-            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
-        }
-
-        [Fact]
-        public void Should_specify_requests_matching_given_path_and_method_get()
-        {
-            // given
-            var spec = Request.Create().WithPath("/foo").UsingGet();
-
-            // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "GET", ClientIp);
-
-            // then
-            var requestMatchResult = new RequestMatchResult();
-            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
-        }
-
-        [Fact]
-        public void Should_specify_requests_matching_given_path_and_method_delete()
-        {
-            // given
-            var spec = Request.Create().WithPath("/foo").UsingDelete();
-
-            // when
-            string bodyAsString = "whatever";
-            byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "Delete", ClientIp, body, bodyAsString, Encoding.UTF8);
-
-            // then
-            var requestMatchResult = new RequestMatchResult();
-            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
-        }
-
-        [Fact]
-        public void Should_specify_requests_matching_given_path_and_method_head()
-        {
-            // given
-            var spec = Request.Create().WithPath("/foo").UsingHead();
-
-            // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "HEAD", ClientIp);
-
-            // then
-            var requestMatchResult = new RequestMatchResult();
-            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsEqualTo(1.0);
-        }
-
-        [Fact]
-        public void Should_exclude_requests_matching_given_path_but_not_http_method()
-        {
-            // given
-            var spec = Request.Create().WithPath("/foo").UsingPut();
-
-            // when
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "HEAD", ClientIp);
-
-            // then
-            var requestMatchResult = new RequestMatchResult();
-            Check.That(spec.GetMatchingScore(request, requestMatchResult)).IsNotEqualTo(1.0);
-        }
-
-        [Fact]
         public void Should_exclude_requests_matching_given_http_method_but_not_url()
         {
             // given
@@ -206,7 +120,7 @@ namespace WireMock.Net.Tests
             // when
             string bodyAsString = "whatever";
             byte[] body = Encoding.UTF8.GetBytes(bodyAsString);
-            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string[]> { { "X-toto", new [] { "tata" } } });
+            var request = new RequestMessage(new Uri("http://localhost/foo"), "PUT", ClientIp, body, bodyAsString, Encoding.UTF8, new Dictionary<string, string[]> { { "X-toto", new[] { "tata" } } });
 
             // then
             var requestMatchResult = new RequestMatchResult();


### PR DESCRIPTION
If you need to mock an API designed to the JsonAPI specification you need to work with PATCH requests with a http body. This fix and tests should allow support of PATCH with body and ensure the correct information gets logged.

- Patch requests not configured to support Body
- Add a unit test covering a patch request and logging of results