### PR TITLE
Capturing the index of the existing mapping before removing and insert the updated mapping at the same index of the list

### DIFF
--- a/src/WireMock.Net/Server/FluentMockServer.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.cs
@@ -372,9 +372,32 @@ namespace WireMock.Server
         private void RegisterMapping(Mapping mapping)
         {
             // Check a mapping exists with the same GUID, if so, remove it first.
+
+            // If the mapping exists then capture the index of the mapping and insert it later at the same index
+
+            var index = GetMappingIndex(mapping.Guid);
+
             DeleteMapping(mapping.Guid);
 
-            _options.Mappings.Add(mapping);
+            if (index != -1)
+            {
+                _options.Mappings.Insert(index, mapping);
+            }
+            else
+            {
+                _options.Mappings.Add(mapping);
+            }
+        }
+
+        private int GetMappingIndex(Guid guid)
+        {
+            var existingMapping = _options.Mappings.FirstOrDefault(m => m.Guid == guid);
+            if (existingMapping != null)
+            {
+                return _options.Mappings.IndexOf(existingMapping);
+            }
+
+            return -1;
         }
     }
 }

--- a/src/WireMock.Net/Server/FluentMockServer.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.cs
@@ -371,9 +371,7 @@ namespace WireMock.Server
         /// </param>
         private void RegisterMapping(Mapping mapping)
         {
-            // Check a mapping exists with the same GUID, if so, remove it first.
-
-            // If the mapping exists then capture the index of the mapping and insert it later at the same index
+            // Check a mapping exists with the same GUID, if so, replace it
 
             var index = GetMappingIndex(mapping.Guid);
 


### PR DESCRIPTION
This is to fix the issue #73 
We are inserting the updated mapping with the same guid in the same position rather than at the end of the list. This will keep the list state intact