### PR TITLE
Fix missed content headers

### DIFF
--- a/src/WireMock.Net/Http/HttpClientHelper.cs
+++ b/src/WireMock.Net/Http/HttpClientHelper.cs
@@ -62,7 +62,7 @@ namespace WireMock.Http
             var httpRequestMessage = new HttpRequestMessage(new HttpMethod(requestMessage.Method), url);
 
             // Set Body if present
-            if (requestMessage.BodyAsBytes != null && requestMessage.BodyAsBytes.Length > 0)
+            if (requestMessage.BodyAsBytes != null)
             {
                 httpRequestMessage.Content = new ByteArrayContent(requestMessage.BodyAsBytes);
             }


### PR DESCRIPTION
We need to pass the content headers even if the content is empty.
* fixed issue with passing content headers
* added test for checking the content header when the content is empty