### PR TITLE
Respect start timeout setting and expose exception from server startup

### DIFF
--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using WireMock.Http;
 using WireMock.HttpsCertificate;
+using WireMock.Logging;
 using WireMock.Validation;
 
 namespace WireMock.Owin
@@ -18,6 +19,8 @@ namespace WireMock.Owin
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         private readonly WireMockMiddlewareOptions _options;
         private readonly string[] _urls;
+        private readonly IWireMockLogger _logger;
+        private Exception _runningException;
 
         private IWebHost _host;
 
@@ -27,10 +30,14 @@ namespace WireMock.Owin
 
         public List<int> Ports { get; } = new List<int>();
 
+        public Exception RunningException => _runningException;
+
         public AspNetCoreSelfHost([NotNull] WireMockMiddlewareOptions options, [NotNull] params string[] uriPrefixes)
         {
             Check.NotNull(options, nameof(options));
             Check.NotNullOrEmpty(uriPrefixes, nameof(uriPrefixes));
+
+            _logger = options.Logger ?? new WireMockConsoleLogger();
 
             foreach (string uriPrefix in uriPrefixes)
             {
@@ -89,20 +96,35 @@ namespace WireMock.Owin
 
             IsStarted = true;
 
-#if NETSTANDARD1_3
-            Console.WriteLine("WireMock.Net server using netstandard1.3");
             return Task.Run(() =>
             {
-                _host.Run(_cts.Token);
+                StartServers();
             }, _cts.Token);
-#else
-            System.Console.WriteLine("WireMock.Net server using netstandard2.0");
+        }
 
-            return Task.Run(() =>
+        private void StartServers()
+        {
+            try
             {
+                IsStarted = true;
+#if NETSTANDARD1_3
+                _logger.Info("WireMock.Net server using netstandard1.3");           
+                _host.Run(_cts.Token);
+#else
+                _logger.Info("WireMock.Net server using netstandard2.0");
                 _host.Run();
-            }, _cts.Token);
 #endif
+                
+            }
+            catch (Exception e)
+            {
+                _runningException = e;
+                _logger.Error(e.ToString());
+            }
+            finally
+            {
+                IsStarted = false;
+            }
         }
 
         public Task StopAsync()

--- a/src/WireMock.Net/Owin/IOwinSelfHost.cs
+++ b/src/WireMock.Net/Owin/IOwinSelfHost.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using System;
 
 namespace WireMock.Owin
 {
@@ -28,6 +29,11 @@ namespace WireMock.Owin
         /// The ports.
         /// </value>
         List<int> Ports { get; }
+
+        /// <summary>
+        /// Determind an exception occurred in host running
+        /// </summary>
+        Exception RunningException { get; }
 
         Task StartAsync();
 

--- a/src/WireMock.Net/Owin/OwinSelfHost.cs
+++ b/src/WireMock.Net/Owin/OwinSelfHost.cs
@@ -1,13 +1,14 @@
 ﻿#if !NETSTANDARD
+using JetBrains.Annotations;
+using Microsoft.Owin.Hosting;
+using Owin;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using JetBrains.Annotations;
-using WireMock.Validation;
-using Owin;
-using Microsoft.Owin.Hosting;
 using WireMock.Http;
+using WireMock.Logging;
+using WireMock.Validation;
 
 namespace WireMock.Owin
 {
@@ -15,11 +16,15 @@ namespace WireMock.Owin
     {
         private readonly WireMockMiddlewareOptions _options;
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly IWireMockLogger _logger;
+        private Exception _runningException;
 
         public OwinSelfHost([NotNull] WireMockMiddlewareOptions options, [NotNull] params string[] uriPrefixes)
         {
             Check.NotNull(options, nameof(options));
             Check.NotNullOrEmpty(uriPrefixes, nameof(uriPrefixes));
+
+            _logger = options.Logger ?? new WireMockConsoleLogger();
 
             foreach (string uriPrefix in uriPrefixes)
             {
@@ -37,6 +42,8 @@ namespace WireMock.Owin
         public List<string> Urls { get; } = new List<string>();
 
         public List<int> Ports { get; } = new List<int>();
+
+        public Exception RunningException => _runningException;
 
         [PublicAPI]
         public Task StartAsync()
@@ -58,37 +65,48 @@ namespace WireMock.Owin
         private void StartServers()
         {
 #if NET46
-            Console.WriteLine("WireMock.Net server using .net 4.6.x or higher");
+            _logger.Info("WireMock.Net server using .net 4.6.x or higher");
 #else
-            Console.WriteLine("WireMock.Net server using .net 4.5.x or higher");
+            _logger.Info("WireMock.Net server using .net 4.5.x or higher");
 #endif
-
-            Action<IAppBuilder> startup = app =>
+            try
             {
-                app.Use<GlobalExceptionMiddleware>(_options);
-                _options.PreWireMockMiddlewareInit?.Invoke(app);
-                app.Use<WireMockMiddleware>(_options);
-                _options.PostWireMockMiddlewareInit?.Invoke(app);
-            };
+                Action<IAppBuilder> startup = app =>
+                {
+                    app.Use<GlobalExceptionMiddleware>(_options);
+                    _options.PreWireMockMiddlewareInit?.Invoke(app);
+                    app.Use<WireMockMiddleware>(_options);
+                    _options.PostWireMockMiddlewareInit?.Invoke(app);
+                };
 
-            var servers = new List<IDisposable>();
-            foreach (var url in Urls)
-            {
-                servers.Add(WebApp.Start(url, startup));
+                var servers = new List<IDisposable>();
+                foreach (var url in Urls)
+                {
+                    servers.Add(WebApp.Start(url, startup));
+                }
+
+                IsStarted = true;
+
+                // WaitHandle is signaled when the token is cancelled,
+                // which will be more efficent than Thread.Sleep in while loop
+                _cts.Token.WaitHandle.WaitOne();
+
+                foreach (var server in servers)
+                {
+                    server.Dispose();
+                }
             }
-
-            IsStarted = true;
-
-            while (!_cts.IsCancellationRequested)
+            catch (Exception e)
             {
-                Thread.Sleep(30000);
+                // Expose exception of starting host, otherwise it's hard to be troubleshooting if keeping quiet
+                // For example, WebApp.Start will fail with System.MissingMemberException if Microsoft.Owin.Host.HttpListener.dll is being located
+                // https://stackoverflow.com/questions/25090211/owin-httplistener-not-located/31369857
+                _runningException = e;
+                _logger.Error(e.ToString());
             }
-
-            IsStarted = false;
-
-            foreach (var server in servers)
+            finally
             {
-                server.Dispose();
+                IsStarted = false;
             }
         }
     }


### PR DESCRIPTION
1. Respect the start timeout setting
2. Expose error(exception) from server startup
3. To be more efficient in waiting server startup