### PR TITLE
Cancellation token not passed to server instance in .NET Core 2

### DIFF
--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
@@ -110,7 +110,7 @@ namespace WireMock.Owin
                 _host.Run(_cts.Token);
 #else
                 _logger.Info("WireMock.Net server using netstandard2.0");
-                _host.Run();
+                _host.RunAsync(_cts.Token).Wait();
 #endif
             }
             catch (Exception e)

--- a/src/WireMock.Net/Server/FluentMockServer.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.cs
@@ -248,7 +248,9 @@ namespace WireMock.Server
         [PublicAPI]
         public void Stop()
         {
-            _httpServer?.StopAsync();
+            var result = _httpServer?.StopAsync();
+            if (result != null)
+                result.Wait();          //wait for stop to actually happen
         }
         #endregion
 


### PR DESCRIPTION
Fix code for .NET Core 2 so that server has cancellation token, and Stop method waits for shutdown.  This resolves issues when using .NET Core 2 and starting/stopping server instances.