### PR TITLE
Set Content-Type header for PutMappingAsync in the client

### DIFF
--- a/src/WireMock.Net/Client/IFluentMockServerAdmin.cs
+++ b/src/WireMock.Net/Client/IFluentMockServerAdmin.cs
@@ -84,6 +84,7 @@ namespace WireMock.Client
         /// <param name="guid">The Guid</param>
         /// <param name="mapping">MappingModel</param>
         [Put("__admin/mappings/{guid}")]
+        [Header("Content-Type", "application/json")]
         Task<StatusModel> PutMappingAsync([Path] Guid guid, [Body] MappingModel mapping);
 
         /// <summary>


### PR DESCRIPTION
Resolves https://github.com/WireMock-Net/WireMock.Net/issues/182