### PR TITLE
Set IsStarted = true in a IApplicationLifetime.ApplicationStarted listener

### DIFF
--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
@@ -104,7 +104,9 @@ namespace WireMock.Owin
         {
             try
             {
-                IsStarted = true;
+                var appLifetime = (IApplicationLifetime) _host.Services.GetService(typeof(IApplicationLifetime));
+                appLifetime.ApplicationStarted.Register(() => IsStarted = true);
+
 #if NETSTANDARD1_3
                 _logger.Info("WireMock.Net server using netstandard1.3");
 #elif NETSTANDARD2_0


### PR DESCRIPTION
Should ensure the server is actually listening for client connections. See #196. 