### PR TITLE
Fix BodyAsJson transform bug in ResponseMessageTransformer

### DIFF
--- a/src/WireMock.Net/Transformers/ResponseMessageTransformer.cs
+++ b/src/WireMock.Net/Transformers/ResponseMessageTransformer.cs
@@ -67,7 +67,7 @@ namespace WireMock.Transformers
             switch (original.BodyData.BodyAsJson)
             {
                 case JObject bodyAsJObject:
-                    jToken = bodyAsJObject;
+                    jToken = bodyAsJObject.DeepClone();
                     break;
 
                 case Array bodyAsArray:


### PR DESCRIPTION
Fix ResponseMessageTransformer to not replace BodyAsJson in an original message with transformed results