### PR TITLE
workaround for AppContext.BaseDirectory being null on some platforms

### DIFF
--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
@@ -56,7 +56,18 @@ namespace WireMock.Owin
 
         public Task StartAsync()
         {
-            _host = new WebHostBuilder()
+            var builder = new WebHostBuilder();
+
+            // Workaround for https://github.com/WireMock-Net/WireMock.Net/issues/292
+            // On some platforms, AppContext.BaseDirectory is null, which causes WebHostBuilder to fail if ContentRoot is not
+            // specified (even though we don't actually use that base path mechanism, since we have our own way of configuring
+            // a filesystem handler).
+            if (string.IsNullOrEmpty(AppContext.BaseDirectory))
+            {
+                builder.UseContentRoot(System.IO.Directory.GetCurrentDirectory());
+            }
+
+            _host = builder
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton(_options.FileSystemHandler);


### PR DESCRIPTION
This addresses https://github.com/WireMock-Net/WireMock.Net/issues/292 which is known to affect Xamarin Android.

I'm not aware of any other platforms where this is a problem, but if there are any, the principle is the same: if AppContext.BaseDirectory is null, then WebHostBuilder won't work without setting ContentRoot. WireMock.Net wouldn't work at all under that condition before, so the workaround can't hurt - and the workaround is only used in that condition, so platforms where WireMock.Net _did_ work are not affected.

I don't know of any way to unit-test this change, since it's not possible to change AppContext.BaseDirectory dynamically in a test. However, I have tested manually in Xamarin Android and it solved the problem for me.