### PR TITLE
don't strip request body if we don't recognize the request method

### DIFF
--- a/src/WireMock.Net/Util/BodyParser.cs
+++ b/src/WireMock.Net/Util/BodyParser.cs
@@ -65,7 +65,7 @@ namespace WireMock.Util
 
         public static bool ShouldParseBody([CanBeNull] string method)
         {
-            if (method == null)
+            if (String.IsNullOrEmpty(method))
             {
                 return false;
             }

--- a/src/WireMock.Net/Util/BodyParser.cs
+++ b/src/WireMock.Net/Util/BodyParser.cs
@@ -2,6 +2,7 @@
 using MimeKit;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -27,7 +28,18 @@ namespace WireMock.Util
             CONNECT - No defined body semantics
             PATCH - Body supported.
         */
-        private static readonly string[] AllowedBodyParseMethods = { "PUT", "POST", "OPTIONS", "PATCH" };
+        private static readonly IDictionary<string, bool> BodyAllowedForMethods = new Dictionary<string, bool>
+        {
+            { "HEAD", false },
+            { "GET", false },
+            { "PUT", true },
+            { "POST", true },
+            { "DELETE", false },
+            { "TRACE", false },
+            { "OPTIONS", true },
+            { "CONNECT", false },
+            { "PATCH", true }
+        };
 
         private static readonly IStringMatcher[] MultipartContentTypesMatchers = {
             new WildcardMatcher("multipart/*", true)
@@ -53,7 +65,19 @@ namespace WireMock.Util
 
         public static bool ShouldParseBody([CanBeNull] string method)
         {
-            return AllowedBodyParseMethods.Contains(method, StringComparer.OrdinalIgnoreCase);
+            if (method == null)
+            {
+                return false;
+            }
+            if (BodyAllowedForMethods.TryGetValue(method.ToUpper(), out var allowed))
+            {
+                return allowed;
+            }
+            // If we don't have any knowledge of this method, we should assume that a body *may*
+            // be present, so we should parse it if it is. Therefore, if a new method is added to
+            // the HTTP Method Registry, we only really need to add it to BodyAllowedForMethods if
+            // we want to make it clear that a body is *not* allowed.
+            return true;
         }
 
         public static BodyType DetectBodyTypeFromContentType([CanBeNull] string contentTypeValue)

--- a/test/WireMock.Net.Tests/Util/BodyParserTests.cs
+++ b/test/WireMock.Net.Tests/Util/BodyParserTests.cs
@@ -125,5 +125,28 @@ Content-Type: text/html
             Check.That(body.DetectedBodyType).IsEqualTo(detectedBodyType);
             Check.That(body.DetectedBodyTypeFromContentType).IsEqualTo(detectedBodyTypeFromContentType);
         }
+
+        [Theory]
+        [InlineData("HEAD", false)]
+        [InlineData("GET", false)]
+        [InlineData("PUT", true)]
+        [InlineData("POST", true)]
+        [InlineData("DELETE", false)]
+        [InlineData("TRACE", false)]
+        [InlineData("OPTIONS", true)]
+        [InlineData("CONNECT", false)]
+        [InlineData("PATCH", true)]
+        public void BodyParser_ShouldParseBody_ExpectedResultForKnownMethods(string method, bool resultShouldBe)
+        {
+            Check.That(BodyParser.ShouldParseBody(method)).Equals(resultShouldBe);
+        }
+
+        [Theory]
+        [InlineData("REPORT")]
+        [InlineData("SOME-UNKNOWN-METHOD")]
+        public void BodyParser_ShouldParseBody_DefaultIsTrueForUnknownMethods(string method)
+        {
+            Check.That(BodyParser.ShouldParseBody(method)).IsTrue();
+        }
     }
 }


### PR DESCRIPTION
This addresses https://github.com/WireMock-Net/WireMock.Net/issues/290 by changing the request-processing behavior from this--

* Is the request method is one of the specific methods that we _know_ can have a body?
* If so, then preserve the request body.
* Otherwise, discard the request body.

--to this:

* Is the request method is one of the specific methods that we _know_ **_cannot_** have a body?
* If so, then discard the request body.
* Otherwise, preserve the request body.

For any of the methods that were already listed in BodyParser.cs, this change has no effect: request bodies will still be discarded for GET or DELETE, preserved for POST or PUT, etc. But for methods that were not specifically mentioned there (like REPORT), the request body (if any) will be preserved. I believe this is more in line with the HTTP specification, which only says that a server should discard the body if the method is known _not_ to allow one.

While REPORT was the method I wanted to use in my own code, I didn't bother adding it to this list because it's just one of many rarely-used methods that appear in the [HTTP Method Registry](https://www.iana.org/assignments/http-methods).