### PR TITLE
Handles case where parameter value contains ==

### DIFF
--- a/src/WireMock.Net/Util/QueryStringParser.cs
+++ b/src/WireMock.Net/Util/QueryStringParser.cs
@@ -18,11 +18,6 @@ namespace WireMock.Util
 
             string[] JoinParts(string[] parts)
             {
-                if (parts.Length > 2)
-                {
-                    return new[] { string.Join("=", parts, 1, parts.Length - 1) };
-                }
-
                 if (parts.Length > 1)
                 {
                     return parts[1].Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries); // support "?key=1,2"
@@ -33,7 +28,7 @@ namespace WireMock.Util
 
             return queryString.TrimStart('?')
                 .Split(new[] { '&', ';' }, StringSplitOptions.RemoveEmptyEntries) // Support "?key=value;key=anotherValue" and "?key=value&key=anotherValue"
-                .Select(parameter => parameter.Split(new[] { '=' }, StringSplitOptions.RemoveEmptyEntries))
+                .Select(parameter => parameter.Split(new[] { '=' }, 2, StringSplitOptions.RemoveEmptyEntries))
                 .GroupBy(parts => parts[0], JoinParts)
                 .ToDictionary(grouping => grouping.Key, grouping => new WireMockList<string>(grouping.SelectMany(x => x)));
         }

--- a/test/WireMock.Net.Tests/Util/QueryStringParserTests.cs
+++ b/test/WireMock.Net.Tests/Util/QueryStringParserTests.cs
@@ -147,6 +147,20 @@ namespace WireMock.Net.Tests.Util
         }
 
         [Fact]
+        public void Parse_With1ParamWithTwoEqualSigns()
+        {
+            // Assign
+            string query = "?key=value==what";
+
+            // Act
+            var result = QueryStringParser.Parse(query);
+
+            // Assert
+            result.Count.Should().Be(1);
+            result["key"].Should().Equal(new WireMockList<string>("value==what"));
+        }
+
+        [Fact]
         public void Parse_WithMultipleParamWithSameKeySeparatedBySemiColon()
         {
             // Assign


### PR DESCRIPTION
This is a fix for #287; querystring parameters that contain `==` in their value were not being properly parsed, i.e., `?key=value==something`.

The fix here limits splitting each querystring parameter to the first `=` in the string.

I don't see any contributing guidelines, so I'm happy to make changes if need be.  Thank you for a great tool!