### PR TITLE
Make SaveMapping and SaveMappingToFile settings independent.

### DIFF
--- a/src/WireMock.Net/Server/FluentMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.Admin.cs
@@ -266,10 +266,14 @@ namespace WireMock.Server
 
             var responseMessage = await HttpClientHelper.SendAsync(_httpClientForProxy, requestMessage, proxyUriWithRequestPathAndQuery.AbsoluteUri);
 
-            if (settings.ProxyAndRecordSettings.SaveMapping)
+            if (settings.ProxyAndRecordSettings.SaveMapping || settings.ProxyAndRecordSettings.SaveMappingToFile)
             {
                 var mapping = ToMapping(requestMessage, responseMessage, settings.ProxyAndRecordSettings.BlackListedHeaders ?? new string[] { });
-                _options.Mappings.TryAdd(mapping.Guid, mapping);
+
+                if (settings.ProxyAndRecordSettings.SaveMapping)
+                {
+                    _options.Mappings.TryAdd(mapping.Guid, mapping);
+                }
 
                 if (settings.ProxyAndRecordSettings.SaveMappingToFile)
                 {


### PR DESCRIPTION
When both are true - mappings are applied instantly and may affect further requests recording.
It make sense to separate settings and allow to save files without applying them.