### PR TITLE
Fix: Collection was modified exception

### DIFF
--- a/src/WireMock.Net/Server/FluentMockServer.LogEntries.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.LogEntries.cs
@@ -39,7 +39,7 @@ namespace WireMock.Server
         {
             var results = new Dictionary<LogEntry, RequestMatchResult>();
 
-            foreach (var log in _options.LogEntries)
+            foreach (var log in _options.LogEntries.ToList())
             {
                 var requestMatchResult = new RequestMatchResult();
                 foreach (var matcher in matchers)


### PR DESCRIPTION
## Problem
We are using wiremock as part of our tests and we found that if we have tests running in parallel we sometimes get an error when calling the `FindLogEntries` method. 

**Error** 
```
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
```

## Potential Solution
This is my quick attempt at fixing the above issue. By convert the collection into a new list it shouldn't throw an error if the `LogEntries` collection is updated. 
From a quick google around the `ToList` method itself isn't thread safe either though. So its possible that while the `ToList` method is creating a copy, it fails due to the original collection getting changed.


Thoughts?
@StefH 