### PR TITLE
Fix recorded requests skipped by request logger

### DIFF
--- a/src/WireMock.Net/IMapping.cs
+++ b/src/WireMock.Net/IMapping.cs
@@ -78,6 +78,15 @@ namespace WireMock
         /// <c>true</c> if this mapping is an Admin Interface; otherwise, <c>false</c>.
         /// </value>
         bool IsAdminInterface { get; }
+        
+        
+        /// <summary>
+        /// Gets a value indicating whether this mapping is recorded by Proxy.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if this mapping is recorded by Proxy; otherwise, <c>false</c>.
+        /// </value>
+        bool IsRecordedByProxy { get; }
 
         /// <summary>
         /// ProvideResponseAsync

--- a/src/WireMock.Net/IMapping.cs
+++ b/src/WireMock.Net/IMapping.cs
@@ -79,7 +79,6 @@ namespace WireMock
         /// </value>
         bool IsAdminInterface { get; }
         
-        
         /// <summary>
         /// Gets a value indicating whether this mapping is recorded by Proxy.
         /// </summary>

--- a/src/WireMock.Net/IMapping.cs
+++ b/src/WireMock.Net/IMapping.cs
@@ -80,12 +80,12 @@ namespace WireMock
         bool IsAdminInterface { get; }
         
         /// <summary>
-        /// Gets a value indicating whether this mapping is recorded by Proxy.
+        /// Gets a value indicating whether this mapping to be logged.
         /// </summary>
         /// <value>
-        /// <c>true</c> if this mapping is recorded by Proxy; otherwise, <c>false</c>.
+        /// <c>true</c> if this mapping to be logged; otherwise, <c>false</c>.
         /// </value>
-        bool IsRecordedByProxy { get; }
+        bool LogMapping { get; }
 
         /// <summary>
         /// ProvideResponseAsync

--- a/src/WireMock.Net/Mapping.cs
+++ b/src/WireMock.Net/Mapping.cs
@@ -46,7 +46,10 @@ namespace WireMock
         public bool IsStartState => Scenario == null || Scenario != null && NextState != null && ExecutionConditionState == null;
 
         /// <inheritdoc cref="IMapping.IsAdminInterface" />
-        public bool IsAdminInterface => Provider is DynamicResponseProvider || Provider is DynamicAsyncResponseProvider || Provider is ProxyAsyncResponseProvider;
+        public bool IsAdminInterface => Provider is DynamicResponseProvider || Provider is DynamicAsyncResponseProvider;
+
+        /// <inheritdoc cref="IMapping.IsRecordedByProxy" />
+        public bool IsRecordedByProxy => Provider is ProxyAsyncResponseProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Mapping"/> class.

--- a/src/WireMock.Net/Mapping.cs
+++ b/src/WireMock.Net/Mapping.cs
@@ -46,10 +46,10 @@ namespace WireMock
         public bool IsStartState => Scenario == null || Scenario != null && NextState != null && ExecutionConditionState == null;
 
         /// <inheritdoc cref="IMapping.IsAdminInterface" />
-        public bool IsAdminInterface => Provider is DynamicResponseProvider || Provider is DynamicAsyncResponseProvider;
+        public bool IsAdminInterface => Provider is DynamicResponseProvider || Provider is DynamicAsyncResponseProvider || Provider is ProxyAsyncResponseProvider;
 
-        /// <inheritdoc cref="IMapping.IsRecordedByProxy" />
-        public bool IsRecordedByProxy => Provider is ProxyAsyncResponseProvider;
+        /// <inheritdoc cref="IMapping.LogMapping" />
+        public bool LogMapping => !(Provider is DynamicResponseProvider || Provider is DynamicAsyncResponseProvider);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Mapping"/> class.

--- a/src/WireMock.Net/Mapping.cs
+++ b/src/WireMock.Net/Mapping.cs
@@ -46,7 +46,7 @@ namespace WireMock
         public bool IsStartState => Scenario == null || Scenario != null && NextState != null && ExecutionConditionState == null;
 
         /// <inheritdoc cref="IMapping.IsAdminInterface" />
-        public bool IsAdminInterface => Provider is DynamicResponseProvider || Provider is DynamicAsyncResponseProvider || Provider is ProxyAsyncResponseProvider;
+        public bool IsAdminInterface => Provider is DynamicResponseProvider || Provider is DynamicAsyncResponseProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Mapping"/> class.

--- a/src/WireMock.Net/Mapping.cs
+++ b/src/WireMock.Net/Mapping.cs
@@ -46,7 +46,7 @@ namespace WireMock
         public bool IsStartState => Scenario == null || Scenario != null && NextState != null && ExecutionConditionState == null;
 
         /// <inheritdoc cref="IMapping.IsAdminInterface" />
-        public bool IsAdminInterface => Provider is DynamicResponseProvider || Provider is DynamicAsyncResponseProvider;
+        public bool IsAdminInterface => Provider is DynamicResponseProvider || Provider is DynamicAsyncResponseProvider || Provider is ProxyAsyncResponseProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Mapping"/> class.

--- a/src/WireMock.Net/Owin/WireMockMiddleware.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddleware.cs
@@ -7,6 +7,7 @@ using WireMock.Util;
 using Newtonsoft.Json;
 using WireMock.Http;
 using WireMock.Owin.Mappers;
+using WireMock.ResponseProviders;
 using WireMock.Serialization;
 using WireMock.Validation;
 #if !USE_ASPNETCORE
@@ -99,7 +100,7 @@ namespace WireMock.Owin
                     return;
                 }
 
-                logRequest = !targetMapping.IsAdminInterface;
+                logRequest = !targetMapping.IsAdminInterface || targetMapping.Provider is ProxyAsyncResponseProvider;
 
                 if (targetMapping.IsAdminInterface && _options.AuthorizationMatcher != null)
                 {

--- a/src/WireMock.Net/Owin/WireMockMiddleware.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddleware.cs
@@ -100,7 +100,7 @@ namespace WireMock.Owin
                     return;
                 }
 
-                logRequest = !targetMapping.IsAdminInterface || targetMapping.IsRecordedByProxy;
+                logRequest = !targetMapping.IsAdminInterface || targetMapping.LogMapping;
 
                 if (targetMapping.IsAdminInterface && _options.AuthorizationMatcher != null)
                 {
@@ -113,7 +113,7 @@ namespace WireMock.Owin
                     }
                 }
 
-                if (!(targetMapping.IsAdminInterface || targetMapping.IsRecordedByProxy) && _options.RequestProcessingDelay > TimeSpan.Zero)
+                if (!targetMapping.IsAdminInterface && _options.RequestProcessingDelay > TimeSpan.Zero)
                 {
                     await Task.Delay(_options.RequestProcessingDelay.Value);
                 }

--- a/src/WireMock.Net/Owin/WireMockMiddleware.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddleware.cs
@@ -100,7 +100,7 @@ namespace WireMock.Owin
                     return;
                 }
 
-                logRequest = !targetMapping.IsAdminInterface || targetMapping.Provider is ProxyAsyncResponseProvider;
+                logRequest = !targetMapping.IsAdminInterface || targetMapping.IsRecordedByProxy;
 
                 if (targetMapping.IsAdminInterface && _options.AuthorizationMatcher != null)
                 {
@@ -113,7 +113,7 @@ namespace WireMock.Owin
                     }
                 }
 
-                if (!targetMapping.IsAdminInterface && _options.RequestProcessingDelay > TimeSpan.Zero)
+                if (!(targetMapping.IsAdminInterface || targetMapping.IsRecordedByProxy) && _options.RequestProcessingDelay > TimeSpan.Zero)
                 {
                     await Task.Delay(_options.RequestProcessingDelay.Value);
                 }

--- a/src/WireMock.Net/Server/FluentMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.Admin.cs
@@ -445,7 +445,7 @@ namespace WireMock.Server
 
         private IEnumerable<MappingModel> ToMappingModels()
         {
-            return Mappings.Where(m => !(m.IsAdminInterface || m.IsRecordedByProxy)).Select(_mappingConverter.ToMappingModel);
+            return Mappings.Where(m => !m.IsAdminInterface).Select(_mappingConverter.ToMappingModel);
         }
 
         private ResponseMessage MappingsGet(RequestMessage requestMessage)

--- a/src/WireMock.Net/Server/FluentMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.Admin.cs
@@ -445,7 +445,7 @@ namespace WireMock.Server
 
         private IEnumerable<MappingModel> ToMappingModels()
         {
-            return Mappings.Where(m => !m.IsAdminInterface).Select(_mappingConverter.ToMappingModel);
+            return Mappings.Where(m => !(m.IsAdminInterface || m.IsRecordedByProxy)).Select(_mappingConverter.ToMappingModel);
         }
 
         private ResponseMessage MappingsGet(RequestMessage requestMessage)

--- a/test/WireMock.Net.Tests/FluentMockServerTests.Proxy.cs
+++ b/test/WireMock.Net.Tests/FluentMockServerTests.Proxy.cs
@@ -19,6 +19,35 @@ namespace WireMock.Net.Tests
     public class FluentMockServerProxyTests
     {
         [Fact]
+        public async Task FluentMockServer_Proxy_Should_log_proxied_requests()
+        {
+            // Assign
+            var settings = new FluentMockServerSettings
+            {
+                ProxyAndRecordSettings = new ProxyAndRecordSettings
+                {
+                    Url = "http://www.google.com",
+                    SaveMapping = true,
+                    SaveMappingToFile = false
+                }
+            };
+            var server = FluentMockServer.Start(settings);
+            
+            // Act
+            var requestMessage = new HttpRequestMessage
+            {
+                Method = HttpMethod.Get,
+                RequestUri = new Uri(server.Urls[0])
+            };
+            var httpClientHandler = new HttpClientHandler { AllowAutoRedirect = false };
+            await new HttpClient(httpClientHandler).SendAsync(requestMessage);
+
+            // Assert
+            Check.That(server.Mappings).HasSize(2);
+            Check.That(server.LogEntries).HasSize(1);
+        }
+        
+        [Fact]
         public async Task FluentMockServer_Proxy_Should_proxy_responses()
         {
             // Assign
@@ -40,6 +69,7 @@ namespace WireMock.Net.Tests
 
             // Assert
             Check.That(server.Mappings).HasSize(1);
+            Check.That(server.LogEntries).HasSize(1);
             Check.That(content).Contains("google");
         }
 


### PR DESCRIPTION
When proxy is enabled the recorded requests are mistaken (IMO) for admin interface requests and skipped in LogEntries. Actually none of requests logged in proxy mode. It is valuable to monitor that while recording.