### PR TITLE
Admin Delete with mappings in body

### DIFF
--- a/src/WireMock.Net/Server/WireMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/WireMockServer.Admin.cs
@@ -555,7 +555,6 @@ namespace WireMock.Server
 
         private ResponseMessage MappingsDelete(RequestMessage requestMessage)
         {
-            // if we allow body for HTTP Delete & a body is defined
             if (!string.IsNullOrEmpty(requestMessage.Body))
             {
                 var deletedGuids = MappingsDeleteMappingFromBody(requestMessage);

--- a/src/WireMock.Net/Server/WireMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/WireMockServer.Admin.cs
@@ -566,7 +566,7 @@ namespace WireMock.Server
                 else
                 {
                     // return bad request
-                    return ResponseMessageBuilder.Create($"Poorly formed mapping JSON.", 400);
+                    return ResponseMessageBuilder.Create("Poorly formed mapping JSON.", 400);
                 }
             }
             else

--- a/src/WireMock.Net/Server/WireMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/WireMockServer.Admin.cs
@@ -558,9 +558,8 @@ namespace WireMock.Server
             // if we allow body for HTTP Delete & a body is defined
             if (_settings.AllowBodyForAllHttpMethods.HasValue && _settings.AllowBodyForAllHttpMethods.Value && !String.IsNullOrEmpty(requestMessage.Body))
             {
-                List<Guid> deletedGuids = new List<Guid>();
-                bool success = MappingsDeleteMappingFromBody(requestMessage, ref deletedGuids);
-                if (success)
+                IEnumerable<Guid> deletedGuids = MappingsDeleteMappingFromBody(requestMessage);
+                if (deletedGuids != null)
                 {
                     return ResponseMessageBuilder.Create($"Mappings deleted. Affected GUIDs: [{String.Join(", ", deletedGuids?.ToArray())}]");
                 }
@@ -580,8 +579,10 @@ namespace WireMock.Server
             }
         }
 
-        private bool MappingsDeleteMappingFromBody(RequestMessage requestMessage, ref List<Guid> deletedGuids)
+        private IEnumerable<Guid> MappingsDeleteMappingFromBody(RequestMessage requestMessage)
         {
+            List<Guid> deletedGuids = new List<Guid>();
+
             try
             {
                 var mappingModels = DeserializeRequestMessageToArray<MappingModel>(requestMessage);
@@ -603,15 +604,15 @@ namespace WireMock.Server
             catch (ArgumentException a)
             {
                 _settings.Logger.Error("ArgumentException: {0}", a);
-                return false;
+                return null;
             }
             catch (Exception e)
             {
                 _settings.Logger.Error("Exception: {0}", e);
-                return false;
+                return null;
             }
 
-            return true;
+            return deletedGuids;
         }
 
         private ResponseMessage MappingsReset(RequestMessage requestMessage)

--- a/src/WireMock.Net/Server/WireMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/WireMockServer.Admin.cs
@@ -561,7 +561,7 @@ namespace WireMock.Server
                 var deletedGuids = MappingsDeleteMappingFromBody(requestMessage);
                 if (deletedGuids != null)
                 {
-                    return ResponseMessageBuilder.Create($"Mappings deleted. Affected GUIDs: [{string.Join(", ", deletedGuids?.ToArray())}]");
+                    return ResponseMessageBuilder.Create($"Mappings deleted. Affected GUIDs: [{string.Join(", ", deletedGuids.ToArray())}]");
                 }
                 else
                 {

--- a/src/WireMock.Net/Server/WireMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/WireMockServer.Admin.cs
@@ -556,12 +556,12 @@ namespace WireMock.Server
         private ResponseMessage MappingsDelete(RequestMessage requestMessage)
         {
             // if we allow body for HTTP Delete & a body is defined
-            if (!String.IsNullOrEmpty(requestMessage.Body))
+            if (!string.IsNullOrEmpty(requestMessage.Body))
             {
                 IEnumerable<Guid> deletedGuids = MappingsDeleteMappingFromBody(requestMessage);
                 if (deletedGuids != null)
                 {
-                    return ResponseMessageBuilder.Create($"Mappings deleted. Affected GUIDs: [{String.Join(", ", deletedGuids?.ToArray())}]");
+                    return ResponseMessageBuilder.Create($"Mappings deleted. Affected GUIDs: [{string.Join(", ", deletedGuids?.ToArray())}]");
                 }
                 else
                 {

--- a/src/WireMock.Net/Server/WireMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/WireMockServer.Admin.cs
@@ -556,7 +556,7 @@ namespace WireMock.Server
         private ResponseMessage MappingsDelete(RequestMessage requestMessage)
         {
             // if we allow body for HTTP Delete & a body is defined
-            if (_settings.AllowBodyForAllHttpMethods.HasValue && _settings.AllowBodyForAllHttpMethods.Value && !String.IsNullOrEmpty(requestMessage.Body))
+            if (!String.IsNullOrEmpty(requestMessage.Body))
             {
                 IEnumerable<Guid> deletedGuids = MappingsDeleteMappingFromBody(requestMessage);
                 if (deletedGuids != null)

--- a/src/WireMock.Net/Server/WireMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/WireMockServer.Admin.cs
@@ -558,7 +558,7 @@ namespace WireMock.Server
             // if we allow body for HTTP Delete & a body is defined
             if (!string.IsNullOrEmpty(requestMessage.Body))
             {
-                IEnumerable<Guid> deletedGuids = MappingsDeleteMappingFromBody(requestMessage);
+                var deletedGuids = MappingsDeleteMappingFromBody(requestMessage);
                 if (deletedGuids != null)
                 {
                     return ResponseMessageBuilder.Create($"Mappings deleted. Affected GUIDs: [{string.Join(", ", deletedGuids?.ToArray())}]");
@@ -581,7 +581,7 @@ namespace WireMock.Server
 
         private IEnumerable<Guid> MappingsDeleteMappingFromBody(RequestMessage requestMessage)
         {
-            List<Guid> deletedGuids = new List<Guid>();
+            var deletedGuids = new List<Guid>();
 
             try
             {


### PR DESCRIPTION
Using HTTP `Delete `verb, a user can send multiple mapping jsons (with GUIDs) for deletion.
Note: `AllowBodyForAllHttpMethods `must be set to true.