### PR TITLE
Mark FluentMockServer, FluentMockServerSettings, BlacklistedHeaders and BlacklistedCookies as obsolete

### DIFF
--- a/src/WireMock.Net.StandAlone/StandAloneApp.cs
+++ b/src/WireMock.Net.StandAlone/StandAloneApp.cs
@@ -13,9 +13,9 @@ namespace WireMock.Net.StandAlone
     public static class StandAloneApp
     {
         /// <summary>
-        /// Start WireMock.Net standalone Server based on the FluentMockServerSettings.
+        /// Start WireMock.Net standalone Server based on the IWireMockServerSettings.
         /// </summary>
-        /// <param name="settings">The FluentMockServerSettings</param>
+        /// <param name="settings">The IWireMockServerSettings</param>
         [PublicAPI]
         public static WireMockServer Start([NotNull] IWireMockServerSettings settings)
         {

--- a/src/WireMock.Net/Server/FluentMockServer.cs
+++ b/src/WireMock.Net/Server/FluentMockServer.cs
@@ -1,7 +1,9 @@
-﻿using WireMock.Settings;
+﻿using System;
+using WireMock.Settings;
 
 namespace WireMock.Server
 {
+    [Obsolete("Use WireMockServer. This will removed in next version (1.3.x)")]
     public class FluentMockServer : WireMockServer
     {
         public FluentMockServer(IFluentMockServerSettings settings) : base((IWireMockServerSettings) settings)

--- a/src/WireMock.Net/Server/WireMockServer.Admin.cs
+++ b/src/WireMock.Net/Server/WireMockServer.Admin.cs
@@ -290,7 +290,7 @@ namespace WireMock.Server
             return responseMessage;
         }
 
-        private IMapping ToMapping(RequestMessage requestMessage, ResponseMessage responseMessage, string[] blacklistedHeaders, string[] blacklistedCookies)
+        private IMapping ToMapping(RequestMessage requestMessage, ResponseMessage responseMessage, string[] excludedHeaders, string[] excludedCookies)
         {
             var request = Request.Create();
             request.WithPath(requestMessage.Path);
@@ -299,16 +299,16 @@ namespace WireMock.Server
             requestMessage.Query.Loop((key, value) => request.WithParam(key, false, value.ToArray()));
             requestMessage.Cookies.Loop((key, value) =>
             {
-                if (!blacklistedCookies.Contains(key, StringComparer.OrdinalIgnoreCase))
+                if (!excludedCookies.Contains(key, StringComparer.OrdinalIgnoreCase))
                 {
                     request.WithCookie(key, value);
                 }
             });
 
-            var allBlackListedHeaders = new List<string>(blacklistedHeaders) { "Cookie" };
+            var allExcludedHeaders = new List<string>(excludedHeaders) { "Cookie" };
             requestMessage.Headers.Loop((key, value) =>
             {
-                if (!allBlackListedHeaders.Contains(key, StringComparer.OrdinalIgnoreCase))
+                if (!allExcludedHeaders.Contains(key, StringComparer.OrdinalIgnoreCase))
                 {
                     request.WithHeader(key, value.ToArray());
                 }

--- a/src/WireMock.Net/Settings/FluentMockServerSettings.cs
+++ b/src/WireMock.Net/Settings/FluentMockServerSettings.cs
@@ -1,8 +1,11 @@
-﻿namespace WireMock.Settings
+﻿using System;
+
+namespace WireMock.Settings
 {
     /// <summary>
     /// FluentMockServerSettings
     /// </summary>
+    [Obsolete("Use WireMockServerSettings. This will removed in next version (1.3.x)")]
     public class FluentMockServerSettings : WireMockServerSettings
     {
     }

--- a/src/WireMock.Net/Settings/IFluentMockServerSettings.cs
+++ b/src/WireMock.Net/Settings/IFluentMockServerSettings.cs
@@ -1,8 +1,11 @@
-﻿namespace WireMock.Settings
+﻿using System;
+
+namespace WireMock.Settings
 {
     /// <summary>
     /// IFluentMockServerSettings
     /// </summary>
+    [Obsolete("Use IWireMockServerSettings. This will removed in next version (1.3.x)")]
     public interface IFluentMockServerSettings : IWireMockServerSettings
     {
     }

--- a/src/WireMock.Net/Settings/IProxyAndRecordSettings.cs
+++ b/src/WireMock.Net/Settings/IProxyAndRecordSettings.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 
 namespace WireMock.Settings
 {
@@ -38,11 +39,13 @@ namespace WireMock.Settings
         /// <summary>
         /// Defines a list from headers which will excluded from the saved mappings.
         /// </summary>
+        [Obsolete("Will be renamed to ExcludedHeaders in next version (1.3.x)")]
         string[] BlackListedHeaders { get; set; }
 
         /// <summary>
         /// Defines a list of cookies which will excluded from the saved mappings.
         /// </summary>
+        [Obsolete("Will be renamed to ExcludedCookies in next version (1.3.x)")]
         string[] BlackListedCookies { get; set; }
 
         /// <summary>

--- a/src/WireMock.Net/Settings/ProxyAndRecordSettings.cs
+++ b/src/WireMock.Net/Settings/ProxyAndRecordSettings.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 
 namespace WireMock.Settings
 {
@@ -39,16 +40,14 @@ namespace WireMock.Settings
         [PublicAPI]
         public string ClientX509Certificate2ThumbprintOrSubjectName { get; set; }
 
-        /// <summary>
-        /// Defines a list from headers which will excluded from the saved mappings.
-        /// </summary>
+        /// <inheritdoc cref="IProxyAndRecordSettings.BlackListedHeaders"/>
         [PublicAPI]
+        [Obsolete("Will be renamed to ExcludedHeaders in next version (1.3.x)")]
         public string[] BlackListedHeaders { get; set; }
 
-        /// <summary>
-        /// Defines a list of cookies which will excluded from the saved mappings.
-        /// </summary>
+        /// <inheritdoc cref="IProxyAndRecordSettings.BlackListedCookies"/>
         [PublicAPI]
+        [Obsolete("Will be renamed to ExcludedCookies in next version (1.3.x)")]
         public string[] BlackListedCookies { get; set; }
 
         /// <inheritdoc cref="IProxyAndRecordSettings.WebProxySettings"/>

--- a/test/WireMock.Net.Tests/ResponseBuilders/ResponseWithStatusCodeTests.cs
+++ b/test/WireMock.Net.Tests/ResponseBuilders/ResponseWithStatusCodeTests.cs
@@ -11,7 +11,7 @@ namespace WireMock.Net.Tests.ResponseBuilders
 {
     public class ResponseWithStatusCodeTests
     {
-        private readonly Mock<IFluentMockServerSettings> _settingsMock = new Mock<IFluentMockServerSettings>();
+        private readonly Mock<IWireMockServerSettings> _settingsMock = new Mock<IWireMockServerSettings>();
         private const string ClientIp = "::1";
 
         [Theory]

--- a/test/WireMock.Net.Tests/WireMockServer.Proxy.cs
+++ b/test/WireMock.Net.Tests/WireMockServer.Proxy.cs
@@ -152,7 +152,7 @@ namespace WireMock.Net.Tests
                 RequestUri = new Uri($"{server.Urls[0]}{path}"),
                 Content = new StringContent("stringContent")
             };
-            requestMessage.Headers.Add("blacklisted", "exact_match");
+            requestMessage.Headers.Add("foobar", "exact_match");
             requestMessage.Headers.Add("ok", "ok-value");
             await new HttpClient().SendAsync(requestMessage);
 

--- a/test/WireMock.Net.Tests/WireMockServer.Proxy.cs
+++ b/test/WireMock.Net.Tests/WireMockServer.Proxy.cs
@@ -34,7 +34,7 @@ namespace WireMock.Net.Tests
                 }
             };
             var server = WireMockServer.Start(settings);
-            
+
             // Act
             var requestMessage = new HttpRequestMessage
             {
@@ -48,7 +48,7 @@ namespace WireMock.Net.Tests
             Check.That(server.Mappings).HasSize(2);
             Check.That(server.LogEntries).HasSize(1);
         }
-        
+
         [Fact]
         public async Task WireMockServer_Proxy_Should_proxy_responses()
         {
@@ -123,7 +123,7 @@ namespace WireMock.Net.Tests
         }
 
         [Fact]
-        public async Task WireMockServer_Proxy_Should_exclude_blacklisted_content_header_in_mapping()
+        public async Task WireMockServer_Proxy_Should_exclude_ExcludedHeaders_in_mapping()
         {
             // Assign
             string path = $"/prx_{Guid.NewGuid()}";
@@ -139,7 +139,7 @@ namespace WireMock.Net.Tests
                     Url = serverForProxyForwarding.Urls[0],
                     SaveMapping = true,
                     SaveMappingToFile = false,
-                    BlackListedHeaders = new[] { "blacklisted" }
+                    BlackListedHeaders = new[] { "excluded-header-X" }
                 }
             };
             var server = WireMockServer.Start(settings);
@@ -160,12 +160,12 @@ namespace WireMock.Net.Tests
             var mapping = server.Mappings.FirstOrDefault(m => m.Guid != defaultMapping.Guid);
             Check.That(mapping).IsNotNull();
             var matchers = ((Request)mapping.RequestMatcher).GetRequestMessageMatchers<RequestMessageHeaderMatcher>().Select(m => m.Name).ToList();
-            Check.That(matchers).Not.Contains("blacklisted");
+            Check.That(matchers).Not.Contains("excluded-header-X");
             Check.That(matchers).Contains("ok");
         }
 
         [Fact]
-        public async Task WireMockServer_Proxy_Should_exclude_blacklisted_cookies_in_mapping()
+        public async Task WireMockServer_Proxy_Should_exclude_ExcludedCookies_in_mapping()
         {
             // Assign
             string path = $"/prx_{Guid.NewGuid()}";
@@ -515,7 +515,7 @@ namespace WireMock.Net.Tests
             content.Should().Contain("known"); // On Linux it's "Name or service not known". On Windows it's "No such host is known.".
 
             server.LogEntries.Should().HaveCount(1);
-            ((StatusModel) server.LogEntries.First().ResponseMessage.BodyData.BodyAsJson).Status.Should().Contain("known");
+            ((StatusModel)server.LogEntries.First().ResponseMessage.BodyData.BodyAsJson).Status.Should().Contain("known");
         }
     }
 }


### PR DESCRIPTION
https://github.com/WireMock-Net/WireMock.Net/issues/489