### PR TITLE
Update .NET Core 3.1 example

### DIFF
--- a/examples/WireMock.Net.WebApplication.NETCore2/web.config
+++ b/examples/WireMock.Net.WebApplication.NETCore2/web.config
@@ -5,7 +5,7 @@
   -->
   <system.webServer>
     <handlers>
-      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+      <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
   </system.webServer>

--- a/examples/WireMock.Net.WebApplication.NETCore3/App.cs
+++ b/examples/WireMock.Net.WebApplication.NETCore3/App.cs
@@ -1,22 +1,28 @@
-﻿using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.Hosting;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace WireMock.Net.WebApplication
 {
-    public class App
+    public class App : IHostedService
     {
         private readonly IWireMockService _service;
-        private readonly ILogger _logger;
         
-        public App(IWireMockService service, ILogger logger)
+        public App(IWireMockService service)
         {
             _service = service;
-            _logger = logger;
         }
 
-        public void Run()
+        public Task StartAsync(CancellationToken cancellationToken)
         {
-            _logger.LogInformation("WireMock.Net App running");
-            _service.Run();
+            _service.Start();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _service.Stop();
+            return Task.CompletedTask;
         }
     }
 }

--- a/examples/WireMock.Net.WebApplication.NETCore3/IWireMockService.cs
+++ b/examples/WireMock.Net.WebApplication.NETCore3/IWireMockService.cs
@@ -2,6 +2,8 @@
 {
     public interface IWireMockService
     {
-        void Run();
+        void Start();
+
+        void Stop();
     }
 }

--- a/examples/WireMock.Net.WebApplication.NETCore3/Program.cs
+++ b/examples/WireMock.Net.WebApplication.NETCore3/Program.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using Microsoft.Extensions.Configuration;
+﻿using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using WireMock.Settings;
-// using Microsoft.Extensions.Logging.Console;
 
 namespace WireMock.Net.WebApplication
 {
@@ -11,49 +10,21 @@ namespace WireMock.Net.WebApplication
     {
         public static void Main(string[] args)
         {
-            // Create service collection
-            var serviceCollection = new ServiceCollection();
-            ConfigureServices(serviceCollection);
-
-            // Create service provider
-            var serviceProvider = serviceCollection.BuildServiceProvider();
-
-            // Run app
-            serviceProvider.GetService<App>().Run();
+            CreateHostBuilder(args).Build().Run();
         }
 
-        private static void ConfigureServices(IServiceCollection serviceCollection)
+        private static IHostBuilder CreateHostBuilder(string[] args)
+            => Host.CreateDefaultBuilder(args)
+                .ConfigureServices((host, services) => ConfigureServices(services, host.Configuration));
+
+        private static void ConfigureServices(IServiceCollection services, IConfiguration configuration)
         {
-            // Build configuration
-            var configuration = new ConfigurationBuilder()
-                .SetBasePath(AppContext.BaseDirectory)
-                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-                .AddEnvironmentVariables() // <-- this is needed to to override settings via the Azure Portal App Settings
-                .Build();
+            services.AddLogging(logging => logging.AddConsole().AddDebug());
 
-            // Add LoggerFactory
-            var factory = new LoggerFactory();
-            //var consoleLog = new ConsoleLoggerProvider(configuration.GetSection("Logging"));
-            serviceCollection.AddSingleton(factory
-              //  .AddProvider(configuration.GetSection("Logging"))
-//                .AddDebug()
-  //              .AddAzureWebAppDiagnostics()
-            );
+            services.AddTransient<IWireMockService, WireMockService>();
+            services.Configure<WireMockServerSettings>(configuration.GetSection("WireMockServerSettings"));
 
-            serviceCollection.AddSingleton(factory.CreateLogger("WireMock.Net Logger"));
-
-            // Add access to generic IConfigurationRoot
-            serviceCollection.AddSingleton(configuration);
-
-            // Add access to WireMockServerSettings
-            var settings = configuration.GetSection("WireMockServerSettings").Get<WireMockServerSettings>();
-            serviceCollection.AddSingleton<WireMockServerSettings>(settings);
-
-            // Add services
-            serviceCollection.AddTransient<IWireMockService, WireMockService>();
-
-            // Add app
-            serviceCollection.AddTransient<App>();
+            services.AddHostedService<App>();
         }
     }
 }

--- a/examples/WireMock.Net.WebApplication.NETCore3/Properties/launchSettings.json
+++ b/examples/WireMock.Net.WebApplication.NETCore3/Properties/launchSettings.json
@@ -8,7 +8,7 @@
     },
     "iisExpress": {
       "applicationUrl": "http://localhost:56513/",
-      "sslPort": 0
+      "sslPort": 44304
     }
   },
   "profiles": {

--- a/examples/WireMock.Net.WebApplication.NETCore3/WireMock.Net.WebApplication.NETCore3.csproj
+++ b/examples/WireMock.Net.WebApplication.NETCore3/WireMock.Net.WebApplication.NETCore3.csproj
@@ -7,6 +7,7 @@
     <AssemblyName>WireMock.Net.WebApplication</AssemblyName>
     <RootNamespace>WireMock.Net.WebApplication</RootNamespace>
     <UserSecretsId>efcf4a18-fd7c-4622-1111-336d65290599</UserSecretsId>
+    <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/WireMock.Net.WebApplication.NETCore3/WireMockService.cs
+++ b/examples/WireMock.Net.WebApplication.NETCore3/WireMockService.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Threading;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using WireMock.Admin.Requests;
 using WireMock.Logging;
@@ -11,8 +11,7 @@ namespace WireMock.Net.WebApplication
 {
     public class WireMockService : IWireMockService
     {
-        private static int sleepTime = 30000;
-
+        private WireMockServer _server;
         private readonly ILogger _logger;
         private readonly WireMockServerSettings _settings;
 
@@ -57,27 +56,27 @@ namespace WireMock.Net.WebApplication
             }
         }
 
-        public WireMockService(ILogger logger, WireMockServerSettings settings)
+        public WireMockService(ILogger<WireMockService> logger, IOptions<WireMockServerSettings> settings)
         {
             _logger = logger;
-            _settings = settings;
+            _settings = settings.Value;
 
             _settings.Logger = new Logger(logger);
         }
 
-        public void Run()
+        public void Start()
         {
             _logger.LogInformation("WireMock.Net server starting");
 
-            WireMockServer.Start(_settings);
+            _server = WireMockServer.Start(_settings);
 
             _logger.LogInformation($"WireMock.Net server settings {JsonConvert.SerializeObject(_settings)}");
+        }
 
-            while (true)
-            {
-                _logger.LogInformation("WireMock.Net server running");
-                Thread.Sleep(sleepTime);
-            }
+        public void Stop()
+        {
+            _logger.LogInformation("WireMock.Net server stopping");
+            _server?.Stop();
         }
     }
 }

--- a/examples/WireMock.Net.WebApplication.NETCore3/web.config
+++ b/examples/WireMock.Net.WebApplication.NETCore3/web.config
@@ -7,6 +7,6 @@
     <handlers>
       <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
     </handlers>
-    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" hostingModel="InProcess" />
+    <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false" />
   </system.webServer>
 </configuration>


### PR DESCRIPTION
* Apply `ILogger`, `IOptions`, `IHostedService` patterns to .NET Core 3.1 example
* Trim unnecessary bits
* Enforce 'Out-of-process' hosting model or the example will not run correctly
* Consolidated line-ending in two files