### PR TITLE
Make kestrel limits configurable

### DIFF
--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard.cs
@@ -3,6 +3,8 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace WireMock.Owin
 {
@@ -32,6 +34,25 @@ namespace WireMock.Owin
                     options.Listen(System.Net.IPAddress.Any, detail.Port);
                 }
             }
+        }
+    }
+
+    internal static class IWebHostBuilderExtensions
+    {
+        internal static IWebHostBuilder ConfigureAppConfigurationUsingEnvironmentVariables(this IWebHostBuilder builder)
+        {
+            return builder.ConfigureAppConfiguration(config =>
+            {
+                config.AddEnvironmentVariables();
+            });
+        }
+
+        internal static IWebHostBuilder ConfigureKestrelServerOptions(this IWebHostBuilder builder)
+        {
+            return builder.ConfigureServices((context, services) =>
+            {
+                services.Configure<KestrelServerOptions>(context.Configuration.GetSection("Kestrel"));
+            });
         }
     }
 }

--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard13.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard13.cs
@@ -33,7 +33,17 @@ namespace WireMock.Owin
     {
         internal static IWebHostBuilder ConfigureAppConfigurationUsingEnvironmentVariables(this IWebHostBuilder builder) => builder;
 
-        internal static IWebHostBuilder ConfigureKestrelServerOptions(this IWebHostBuilder builder) => builder;
+        internal static IWebHostBuilder ConfigureKestrelServerOptions(this IWebHostBuilder builder)
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddEnvironmentVariables()
+                .Build();
+
+            return builder.ConfigureServices(services =>
+            {
+                services.Configure<KestrelServerOptions>(configuration.GetSection("Kestrel"));
+            });
+        }
     }
 }
 #endif

--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard13.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard13.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using WireMock.HttpsCertificate;
 
 namespace WireMock.Owin
@@ -25,6 +27,13 @@ namespace WireMock.Owin
                 options.UseHttps(PublicCertificateHelper.GetX509Certificate2());
             }
         }
+    }
+
+    internal static class IWebHostBuilderExtensions
+    {
+        internal static IWebHostBuilder ConfigureAppConfigurationUsingEnvironmentVariables(this IWebHostBuilder builder) => builder;
+
+        internal static IWebHostBuilder ConfigureKestrelServerOptions(this IWebHostBuilder builder) => builder;
     }
 }
 #endif

--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
@@ -64,7 +64,7 @@ namespace WireMock.Owin
                 {
                     var env = builderContext.HostingEnvironment;
 
-                    config.AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                    config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
                         .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
                         .AddEnvironmentVariables();
                 })

--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using WireMock.Logging;
 using WireMock.Owin.Mappers;
@@ -59,16 +58,7 @@ namespace WireMock.Owin
             }
 
             _host = builder
-#if !NETSTANDARD1_3
-                .ConfigureAppConfiguration((builderContext, config) =>
-                {
-                    var env = builderContext.HostingEnvironment;
-
-                    config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                        .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true)
-                        .AddEnvironmentVariables();
-                })
-#endif
+                .ConfigureAppConfigurationUsingEnvironmentVariables()
                 .ConfigureServices(services =>
                 {
                     services.AddSingleton(_options);
@@ -92,13 +82,7 @@ namespace WireMock.Owin
 
                     SetHttpsAndUrls(options, _urlOptions.GetDetails());
                 })
-#if !NETSTANDARD1_3
-                .ConfigureServices((context, services) =>
-                {
-                    services.Configure<Microsoft.AspNetCore.Server.Kestrel.Core.KestrelServerOptions>(
-                        context.Configuration.GetSection("Kestrel"));
-                })
-#endif
+                .ConfigureKestrelServerOptions()
 
 #if NETSTANDARD1_3
                 .UseUrls(_urlOptions.GetDetails().Select(u => u.Url).ToArray())


### PR DESCRIPTION
* Allow Kestrel limits options to be overridden with values of config files and environment variables (see [related Microsoft documentation](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/servers/kestrel?view=aspnetcore-3.1#kestrel-options)).
