### PR TITLE
Fix response date header

### DIFF
--- a/src/WireMock.Net/Owin/Mappers/OwinResponseMapper.cs
+++ b/src/WireMock.Net/Owin/Mappers/OwinResponseMapper.cs
@@ -154,7 +154,13 @@ namespace WireMock.Owin.Mappers
         private static void SetResponseHeaders(ResponseMessage responseMessage, IResponse response)
         {
             // Force setting the Date header (#577)
-            AppendResponseHeader(response, HttpKnownHeaderNames.Date, new[] { string.Format(CultureInfo.InvariantCulture.DateTimeFormat.RFC1123Pattern, CultureInfo.InvariantCulture.DateTimeFormat.RFC1123Pattern, DateTime.Now) });
+            AppendResponseHeader(
+                response,
+                HttpKnownHeaderNames.Date,
+                new[]
+                {
+                    DateTime.UtcNow.ToString(CultureInfo.InvariantCulture.DateTimeFormat.RFC1123Pattern, CultureInfo.InvariantCulture)
+                });
 
             // Set other headers
             foreach (var item in responseMessage.Headers)


### PR DESCRIPTION
I noticed two things while updating from 1.4.1 to 1.4.4.

First - is an issue with formatting in Date header.
The DateTimeFormat.RFC1123Pattern can't be used with string.Format, since it doesn't seem to have {0} placeholder. Also the RFC1123Pattern is supplied not only as the 'format' parameter, but also as 'arg0' parameter.
I replaced string.Format with date.ToString(...).
Here is the output from simple console example:
```
Current: ddd, dd MMM yyyy HH':'mm':'ss 'GMT'
Fix: Thu, 11 Feb 2021 11:53:02 GMT
```

The second thing - it looks like the date header can't be in local time (at least developer.mozilla.org says that. I didn't read the actual standard, so might be wrong).
I'm not sure if there is a reason current implementation uses DateTime.Now instead of DateTime.UtcNow, but I also added this to PR.

Will appreciate the feedback. Thanks