### PR TITLE
Remove 2 second delay from first response and add IPv6 address support

### DIFF
--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard.cs
@@ -24,7 +24,7 @@ namespace WireMock.Owin
             {
                 if (urlDetail.IsHttps)
                 {
-                    kestrelOptions.Listen(System.Net.IPAddress.Any, urlDetail.Port, listenOptions =>
+                    kestrelOptions.ListenAnyIP(urlDetail.Port, listenOptions =>
                     {
                         if (wireMockMiddlewareOptions.CustomCertificateDefined)
                         {
@@ -45,7 +45,7 @@ namespace WireMock.Owin
                 }
                 else
                 {
-                    kestrelOptions.Listen(System.Net.IPAddress.Any, urlDetail.Port);
+                    kestrelOptions.ListenAnyIP(urlDetail.Port);
                 }
             }
         }

--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
@@ -106,7 +106,7 @@ namespace WireMock.Owin
 
                     foreach (string address in addresses)
                     {
-                        Urls.Add(address.Replace("0.0.0.0", "localhost"));
+                        Urls.Add(address.Replace("0.0.0.0", "localhost").Replace("[::]", "localhost"));
 
                         PortUtils.TryExtract(address, out bool isHttps, out string protocol, out string host, out int port);
                         Ports.Add(port);

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -305,5 +305,51 @@ namespace WireMock.Net.Tests
 
             server.Stop();
         }
+ 
+#if !NET452
+        [Fact]
+        public async Task WireMockServer_Should_respond_to_ipv4_loopback()
+        {
+            // Assign
+            var server = WireMockServer.Start();
+
+            server
+                .Given(Request.Create()
+                    .WithPath("/*"))
+                .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody("from ipv4 loopback"));
+
+            // Act
+            var response = await new HttpClient().GetStringAsync($"http://127.0.0.1:{server.Ports[0]}/foo");
+
+            // Assert
+            Check.That(response).IsEqualTo("from ipv4 loopback");
+
+            server.Stop();
+        }
+
+        [Fact]
+        public async Task WireMockServer_Should_respond_to_ipv6_loopback()
+        {
+            // Assign
+            var server = WireMockServer.Start();
+
+            server
+                .Given(Request.Create()
+                    .WithPath("/*"))
+                .RespondWith(Response.Create()
+                    .WithStatusCode(200)
+                    .WithBody("from ipv6 loopback"));
+
+            // Act
+            var response = await new HttpClient().GetStringAsync($"http://[::1]:{server.Ports[0]}/foo");
+
+            // Assert
+            Check.That(response).IsEqualTo("from ipv6 loopback");
+
+            server.Stop();
+        }
+#endif
     }
 }


### PR DESCRIPTION
Fixes #554 

Remove an approximate two second delay in response to the first request from a new socket connection, apparently only occuring on some Windows 10 machines when using .Net Core.

A side-effect of this fix is that is also allows connections to IPv6 addresses.