### PR TITLE
Allow to add custom service registrations when using ASP.NET Core

### DIFF
--- a/examples/WireMock.Net.Console.Net452.Classic/MainApp.cs
+++ b/examples/WireMock.Net.Console.Net452.Classic/MainApp.cs
@@ -59,6 +59,7 @@ namespace WireMock.Net.ConsoleApplication
                 //},
                 PreWireMockMiddlewareInit = app => { System.Console.WriteLine($"PreWireMockMiddlewareInit : {app.GetType()}"); },
                 PostWireMockMiddlewareInit = app => { System.Console.WriteLine($"PostWireMockMiddlewareInit : {app.GetType()}"); },
+                AdditionalServiceRegistration = services => { System.Console.WriteLine($"AdditionalServiceRegistration : {services.GetType()}"); },
                 Logger = new WireMockConsoleLogger(),
 
                 HandlebarsRegistrationCallback = (handlebarsContext, fileSystemHandler) =>

--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.cs
@@ -66,6 +66,8 @@ namespace WireMock.Owin
                     services.AddSingleton<IMappingMatcher, MappingMatcher>();
                     services.AddSingleton<IOwinRequestMapper, OwinRequestMapper>();
                     services.AddSingleton<IOwinResponseMapper, OwinResponseMapper>();
+
+                    _wireMockMiddlewareOptions.AdditionalServiceRegistration?.Invoke(services);
                 })
                 .Configure(appBuilder =>
                 {

--- a/src/WireMock.Net/Owin/IWireMockMiddlewareOptions.cs
+++ b/src/WireMock.Net/Owin/IWireMockMiddlewareOptions.cs
@@ -8,6 +8,7 @@ using WireMock.Util;
 using Owin;
 #else
 using IAppBuilder = Microsoft.AspNetCore.Builder.IApplicationBuilder;
+using Microsoft.Extensions.DependencyInjection;
 #endif
 
 namespace WireMock.Owin
@@ -35,6 +36,10 @@ namespace WireMock.Owin
         Action<IAppBuilder> PreWireMockMiddlewareInit { get; set; }
 
         Action<IAppBuilder> PostWireMockMiddlewareInit { get; set; }
+
+#if USE_ASPNETCORE
+        Action<IServiceCollection> AdditionalServiceRegistration { get; set; }
+#endif
 
         IFileSystemHandler FileSystemHandler { get; set; }
 

--- a/src/WireMock.Net/Owin/WireMockMiddlewareOptions.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddlewareOptions.cs
@@ -8,6 +8,7 @@ using WireMock.Util;
 using Owin;
 #else
 using IAppBuilder = Microsoft.AspNetCore.Builder.IApplicationBuilder;
+using Microsoft.Extensions.DependencyInjection;
 #endif
 
 namespace WireMock.Owin
@@ -35,6 +36,10 @@ namespace WireMock.Owin
         public Action<IAppBuilder> PreWireMockMiddlewareInit { get; set; }
 
         public Action<IAppBuilder> PostWireMockMiddlewareInit { get; set; }
+
+#if USE_ASPNETCORE
+        public Action<IServiceCollection> AdditionalServiceRegistration { get; set; }
+#endif
 
         /// <inheritdoc cref="IWireMockMiddlewareOptions.FileSystemHandler"/>
         public IFileSystemHandler FileSystemHandler { get; set; }

--- a/src/WireMock.Net/Server/WireMockServer.cs
+++ b/src/WireMock.Net/Server/WireMockServer.cs
@@ -242,6 +242,7 @@ namespace WireMock.Server
             _mappingToFileSaver = new MappingToFileSaver(_settings, _mappingConverter);
 
 #if USE_ASPNETCORE
+            _options.AdditionalServiceRegistration = _settings.AdditionalServiceRegistration;
             _httpServer = new AspNetCoreSelfHost(_options, urlOptions);
 #else
             _httpServer = new OwinSelfHost(_options, urlOptions);

--- a/src/WireMock.Net/Settings/IWireMockServerSettings.cs
+++ b/src/WireMock.Net/Settings/IWireMockServerSettings.cs
@@ -4,6 +4,9 @@ using JetBrains.Annotations;
 using WireMock.Handlers;
 using WireMock.Logging;
 using WireMock.Matchers;
+#if USE_ASPNETCORE
+using Microsoft.Extensions.DependencyInjection;
+#endif
 
 namespace WireMock.Settings
 {
@@ -108,6 +111,14 @@ namespace WireMock.Settings
         /// </summary>
         [PublicAPI]
         Action<object> PostWireMockMiddlewareInit { get; set; }
+
+#if USE_ASPNETCORE
+        /// <summary>
+        /// Action which is called with IServiceCollection when ASP.NET Core DI is being configured. [Optional]
+        /// </summary>
+        [PublicAPI]
+        Action<IServiceCollection> AdditionalServiceRegistration { get; set; }
+#endif
 
         /// <summary>
         /// The IWireMockLogger which logs Debug, Info, Warning or Error

--- a/src/WireMock.Net/Settings/WireMockServerSettings.cs
+++ b/src/WireMock.Net/Settings/WireMockServerSettings.cs
@@ -4,6 +4,9 @@ using JetBrains.Annotations;
 using Newtonsoft.Json;
 using WireMock.Handlers;
 using WireMock.Logging;
+#if USE_ASPNETCORE
+using Microsoft.Extensions.DependencyInjection;
+#endif
 
 namespace WireMock.Settings
 {
@@ -78,6 +81,13 @@ namespace WireMock.Settings
         [PublicAPI]
         [JsonIgnore]
         public Action<object> PostWireMockMiddlewareInit { get; set; }
+
+#if USE_ASPNETCORE
+        /// <inheritdoc cref="IWireMockServerSettings.AdditionalServiceRegistration"/>
+        [PublicAPI]
+        [JsonIgnore]
+        public Action<IServiceCollection> AdditionalServiceRegistration { get; set; }
+#endif
 
         /// <inheritdoc cref="IWireMockServerSettings.Logger"/>
         [PublicAPI]


### PR DESCRIPTION
Since we allow to add custom middleware to WireMock's ASP.NET Core pipeline (using PreWireMockMiddlewareInit/PostWireMockMiddlewareInit), it would make sense to also allow to add custom service registration to ASP.NET Core DI. My specific use case is adding Azure Application Insights telemetry to WireMock's ASP.NET Core host to track external calls from WireMock (mappings with proxy).