### PR TITLE
Support edge case: first object, next an array.

### DIFF
--- a/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
+++ b/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
@@ -152,12 +152,16 @@ namespace WireMock.Net.OpenApiParser.Mappers
                     {
                         string propertyName = schemaProperty.Key;
                         var openApiSchema = schemaProperty.Value;
-                        if (openApiSchema.GetSchemaType() == SchemaType.Object)
+                        if (openApiSchema.GetSchemaType() == SchemaType.Object || openApiSchema.GetSchemaType() == SchemaType.Array)
                         {
                             var mapped = MapSchemaToObject(schemaProperty.Value, schemaProperty.Key);
                             if (mapped is JProperty jp)
                             {
                                 propertyAsJObject.Add(jp);
+                            }
+                            else
+                            {
+                                propertyAsJObject.Add(new JProperty(schemaProperty.Key, mapped));
                             }
                         }
                         else


### PR DESCRIPTION
Hi,

I'm opening this PR 'cause I want to improve the example generation. The edge case is: I have a definition in my openapi file with a property that do reference to an another of type object and it has a reference to other of type array, below an exmaple:

definitions:
  Definition1:
    type: object
    properties:
       mydata:
         type: "array"
          items:
            $ref: "#definitions/Definition2"

  Definition2:
    type: object
    properties:
      property1:
        type: "string"
        format: "string"


