### PR TITLE
Support examples random data generation

### DIFF
--- a/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+namespace WireMock.Net.OpenApiParser.Settings
+{
+    /// <summary>
+    /// A class defining the example values to use for the different types.
+    /// </summary>
+    public interface IWireMockOpenApiParserExampleValues
+    {
+#pragma warning disable 1591
+        bool Boolean { get; set; }        
+        int Integer { get; set; }        
+        float Float { get; set; }        
+
+        double Double { get; set; }        
+
+        Func<DateTime> Date { get; set; }
+
+        Func<DateTime> DateTime { get; set; }        
+
+        byte[] Bytes { get; set; }        
+
+        object Object { get; set; }
+
+        string String { get; set; }
+#pragma warning restore 1591
+    }
+}

--- a/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
@@ -7,7 +7,6 @@ namespace WireMock.Net.OpenApiParser.Settings
     /// </summary>
     public interface IWireMockOpenApiParserExampleValues
     {
-#pragma warning disable 1591
         /// <summary>
         /// An example value for a Boolean.
         /// </summary>
@@ -49,6 +48,5 @@ namespace WireMock.Net.OpenApiParser.Settings
         /// An example value for a String.
         /// </summary>
         string String { get; set; }
-#pragma warning restore 1591
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
@@ -3,25 +3,51 @@
 namespace WireMock.Net.OpenApiParser.Settings
 {
     /// <summary>
-    /// A class defining the example values to use for the different types.
+    /// A interface defining the example values to use for the different types.
     /// </summary>
     public interface IWireMockOpenApiParserExampleValues
     {
 #pragma warning disable 1591
-        bool Boolean { get; set; }        
-        int Integer { get; set; }        
-        float Float { get; set; }        
+        /// <summary>
+        /// An example value for a Boolean.
+        /// </summary>
+        bool Boolean { get; set; }
+        /// <summary>
+        /// An example value for an Integer.
+        /// </summary>
+        int Integer { get; set; }
+        /// <summary>
+        /// An example value for a Float.
+        /// </summary>
+        float Float { get; set; }
+        /// <summary>
+        /// An example value for a Double.
+        /// </summary>
+        double Double { get; set; }
 
-        double Double { get; set; }        
-
+        /// <summary>
+        /// An example value for a Date.
+        /// </summary>
         Func<DateTime> Date { get; set; }
 
-        Func<DateTime> DateTime { get; set; }        
+        /// <summary>
+        /// An example value for a DateTime.
+        /// </summary>
+        Func<DateTime> DateTime { get; set; }
 
-        byte[] Bytes { get; set; }        
+        /// <summary>
+        /// An example value for Bytes.
+        /// </summary>
+        byte[] Bytes { get; set; }
 
+        /// <summary>
+        /// An example value for a Object.
+        /// </summary>
         object Object { get; set; }
 
+        /// <summary>
+        /// An example value for a String.
+        /// </summary>
         string String { get; set; }
 #pragma warning restore 1591
     }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
@@ -9,7 +9,6 @@ namespace WireMock.Net.OpenApiParser.Settings
     /// </summary>
     public class WireMockOpenApiParserDynamicExampleValues : IWireMockOpenApiParserExampleValues
     {
-#pragma warning disable 1591
         /// <inheritdoc />
         public bool Boolean { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBoolean()).Generate() ?? true; } set { } }
         /// <inheritdoc />
@@ -28,6 +27,5 @@ namespace WireMock.Net.OpenApiParser.Settings
         public object Object { get; set; } = "example-object";
         /// <inheritdoc />
         public string String { get { return RandomizerFactory.GetRandomizer(new FieldOptionsTextWords()).Generate() ?? "example-string"; } set { } }
-#pragma warning restore 1591
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
@@ -5,27 +5,28 @@ using RandomDataGenerator.Randomizers;
 namespace WireMock.Net.OpenApiParser.Settings
 {
     /// <summary>
-    /// A class defining the example values to use for the different types.
+    /// A class defining the random example values to use for the different types.
     /// </summary>
     public class WireMockOpenApiParserDynamicExampleValues : IWireMockOpenApiParserExampleValues
     {
 #pragma warning disable 1591
+        /// <inheritdoc />
         public bool Boolean { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBoolean()).Generate() ?? true; } set { } }
-
+        /// <inheritdoc />
         public int Integer { get { return RandomizerFactory.GetRandomizer(new FieldOptionsInteger()).Generate() ?? 42; } set { } }
-
+        /// <inheritdoc />
         public float Float { get { return RandomizerFactory.GetRandomizer(new FieldOptionsFloat()).Generate() ?? 4.2f; } set { } }
-
+        /// <inheritdoc />
         public double Double { get { return RandomizerFactory.GetRandomizer(new FieldOptionsDouble()).Generate() ?? 4.2d; } set { } }
-
+        /// <inheritdoc />
         public Func<DateTime> Date { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow.Date; } set { } }
-
+        /// <inheritdoc />
         public Func<DateTime> DateTime { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow; } set { } }
-
+        /// <inheritdoc />
         public byte[] Bytes { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBytes()).Generate(); } set { } }
-
+        /// <inheritdoc />
         public object Object { get; set; } = "example-object";
-
+        /// <inheritdoc />
         public string String { get { return RandomizerFactory.GetRandomizer(new FieldOptionsTextWords()).Generate() ?? "example-string"; } set { } }
 #pragma warning restore 1591
     }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using RandomDataGenerator.FieldOptions;
+using RandomDataGenerator.Randomizers;
+
+namespace WireMock.Net.OpenApiParser.Settings
+{
+    /// <summary>
+    /// A class defining the example values to use for the different types.
+    /// </summary>
+    public class WireMockOpenApiParserDynamicExampleValues : IWireMockOpenApiParserExampleValues
+    {
+#pragma warning disable 1591
+        public bool Boolean { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBoolean()).Generate() ?? true; } set { } }
+
+        public int Integer { get { return RandomizerFactory.GetRandomizer(new FieldOptionsInteger()).Generate() ?? 42; } set { } }
+
+        public float Float { get { return RandomizerFactory.GetRandomizer(new FieldOptionsFloat()).Generate() ?? 4.2f; } set { } }
+
+        public double Double { get { return RandomizerFactory.GetRandomizer(new FieldOptionsDouble()).Generate() ?? 4.2d; } set { } }
+
+        public Func<DateTime> Date { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow.Date; } set { } }
+
+        public Func<DateTime> DateTime { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow; } set { } }
+
+        public byte[] Bytes { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBytes()).Generate(); } set { } }
+
+        public object Object { get; set; } = "example-object";
+
+        public string String { get { return RandomizerFactory.GetRandomizer(new FieldOptionsTextWords()).Generate() ?? "example-string"; } set { } }
+#pragma warning restore 1591
+    }
+}

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
@@ -8,22 +8,23 @@ namespace WireMock.Net.OpenApiParser.Settings
     public class WireMockOpenApiParserExampleValues : IWireMockOpenApiParserExampleValues
     {
 #pragma warning disable 1591
+        /// <inheritdoc />
         public bool Boolean { get; set; } = true;
-
+        /// <inheritdoc />
         public int Integer { get; set; } = 42;
-
+        /// <inheritdoc />
         public float Float { get; set; } = 4.2f;
-
+        /// <inheritdoc />
         public double Double { get; set; } = 4.2d;
-
+        /// <inheritdoc />
         public Func<DateTime> Date { get; set; } = () => System.DateTime.UtcNow.Date;
-
+        /// <inheritdoc />
         public Func<DateTime> DateTime { get; set; } = () => System.DateTime.UtcNow;
-
+        /// <inheritdoc />
         public byte[] Bytes { get; set; } = { 48, 49, 50 };
-
+        /// <inheritdoc />
         public object Object { get; set; } = "example-object";
-
+        /// <inheritdoc />
         public string String { get; set; } = "example-string";
 #pragma warning restore 1591
     }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
@@ -5,7 +5,7 @@ namespace WireMock.Net.OpenApiParser.Settings
     /// <summary>
     /// A class defining the example values to use for the different types.
     /// </summary>
-    public class WireMockOpenApiParserExampleValues
+    public class WireMockOpenApiParserExampleValues : IWireMockOpenApiParserExampleValues
     {
 #pragma warning disable 1591
         public bool Boolean { get; set; } = true;

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
@@ -7,7 +7,6 @@ namespace WireMock.Net.OpenApiParser.Settings
     /// </summary>
     public class WireMockOpenApiParserExampleValues : IWireMockOpenApiParserExampleValues
     {
-#pragma warning disable 1591
         /// <inheritdoc />
         public bool Boolean { get; set; } = true;
         /// <inheritdoc />
@@ -26,6 +25,5 @@ namespace WireMock.Net.OpenApiParser.Settings
         public object Object { get; set; } = "example-object";
         /// <inheritdoc />
         public string String { get; set; } = "example-string";
-#pragma warning restore 1591
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserSettings.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserSettings.cs
@@ -25,6 +25,11 @@ namespace WireMock.Net.OpenApiParser.Settings
         /// <summary>
         /// The example values to use
         /// </summary>
-        public WireMockOpenApiParserExampleValues ExampleValues { get; } = new WireMockOpenApiParserExampleValues();
+        public IWireMockOpenApiParserExampleValues ExampleValues { get; set; } = new WireMockOpenApiParserExampleValues();
+
+        /// <summary>
+        /// Are examples generated dynamically?
+        /// </summary>
+        public bool DynamicExamples { get; set; } = false;
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Utils/ExampleValueGenerator.cs
+++ b/src/WireMock.Net.OpenApiParser/Utils/ExampleValueGenerator.cs
@@ -13,6 +13,14 @@ namespace WireMock.Net.OpenApiParser.Utils
         public ExampleValueGenerator(WireMockOpenApiParserSettings settings)
         {
             _settings = settings ?? throw new ArgumentNullException(nameof(settings));
+            if (_settings.DynamicExamples)
+            {
+                _settings.ExampleValues = new WireMockOpenApiParserDynamicExampleValues();
+            }
+            else
+            {
+                _settings.ExampleValues = new WireMockOpenApiParserExampleValues();
+            }
         }
 
         public object GetExampleValue(OpenApiSchema schema)

--- a/src/WireMock.Net.OpenApiParser/WireMock.Net.OpenApiParser.csproj
+++ b/src/WireMock.Net.OpenApiParser/WireMock.Net.OpenApiParser.csproj
@@ -25,6 +25,7 @@
 		<PackageReference Include="RamlToOpenApiConverter" Version="0.1.1" />
 		<PackageReference Include="JetBrains.Annotations" Version="2020.1.0" PrivateAssets="All" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+		<PackageReference Include="RandomDataGenerator.Net" Version="1.0.13" />
 		<PackageReference Include="Stef.Validation" Version="0.0.3" />
 	</ItemGroup>
 


### PR DESCRIPTION
Hello @StefH,

I hope you're doing well,

I added the support to Data Generation via `WireMockOpenApiParserSettings` the idea is when the property `DynamicExamples` is true Wiremock.net will be able to randomize the data. I used your awesome library [RandomDataGenerator](https://github.com/StefH/RandomDataGenerator), thanks a lot. 

I hope to see this change soon in nuget, thank you very much Stef, Wiremock.Net has been very useful to me.