### PR TITLE
Fix random generate data in url no spaces

### DIFF
--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
@@ -26,6 +26,6 @@ namespace WireMock.Net.OpenApiParser.Settings
         /// <inheritdoc />
         public object Object { get; set; } = "example-object";
         /// <inheritdoc />
-        public string String { get { return RandomizerFactory.GetRandomizer(new FieldOptionsTextWords()).Generate() ?? "example-string"; } set { } }
+                public string String { get { return RandomizerFactory.GetRandomizer(new FieldOptionsTextRegex { Pattern = @"^[0-9]{2}[A-Z]{5}[0-9]{2}" }).Generate() ?? "example-string"; } set { } }
     }
 }


### PR DESCRIPTION
Hello @StefH ,

I found a bug when the dynamic data has a space, the idea is a simple regexp to build random data without spaces.

Thanks.