### PR TITLE
Support RequestBody

### DIFF
--- a/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
+++ b/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
@@ -6,6 +6,7 @@ using Microsoft.OpenApi;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
 using Microsoft.OpenApi.Writers;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using WireMock.Admin.Mappings;
 using WireMock.Net.OpenApiParser.Extensions;
@@ -108,8 +109,8 @@ namespace WireMock.Net.OpenApiParser.Mappers
 
             BodyModel bodyRequestModel = new BodyModel();
             bodyRequestModel.Matcher = new MatcherModel();
-            bodyRequestModel.Matcher.Name = "ExactMatcher";
-            bodyRequestModel.Matcher.Pattern = requestBody;
+            bodyRequestModel.Matcher.Name = "JsonMatcher";
+            bodyRequestModel.Matcher.Pattern = JsonConvert.SerializeObject(requestBody, Formatting.Indented);
             return bodyRequestModel;
         }
 

--- a/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
+++ b/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
@@ -59,7 +59,7 @@ namespace WireMock.Net.OpenApiParser.Mappers
                                    responseSchemaExample != null ? MapOpenApiAnyToJToken(responseSchemaExample) :
                                    MapSchemaToObject(responseSchema);
 
-            BodyModel requestModeloBody = new BodyModel();
+            BodyModel requestModelBody = new BodyModel();
             if (operation.RequestBody != null && operation.RequestBody.Content != null)
             {
                 var request = operation.RequestBody.Content;
@@ -73,7 +73,7 @@ namespace WireMock.Net.OpenApiParser.Mappers
                                    requestBodySchemaExample != null ? MapOpenApiAnyToJToken(requestBodySchemaExample) :
                                    MapSchemaToObject(requestBodySchema);
 
-                requestModeloBody = MapRequestBody(requestBodyMapped);
+                requestModelBody = MapRequestBody(requestBodyMapped);
             }
 
             if (!int.TryParse(response.Key, out var httpStatusCode))
@@ -90,7 +90,7 @@ namespace WireMock.Net.OpenApiParser.Mappers
                     Path = MapBasePath(servers) + MapPathWithParameters(path, pathParameters),
                     Params = MapQueryParameters(queryParameters),
                     Headers = MapRequestHeaders(headers),
-                    Body = requestModeloBody
+                    Body = requestModelBody
                 },
                 Response = new ResponseModel
                 {

--- a/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
+++ b/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
@@ -59,7 +59,7 @@ namespace WireMock.Net.OpenApiParser.Mappers
                                    responseSchemaExample != null ? MapOpenApiAnyToJToken(responseSchemaExample) :
                                    MapSchemaToObject(responseSchema);
 
-            BodyModel requestModelBody = new BodyModel();
+            var requestBodyModel = new BodyModel();
             if (operation.RequestBody != null && operation.RequestBody.Content != null)
             {
                 var request = operation.RequestBody.Content;
@@ -73,7 +73,7 @@ namespace WireMock.Net.OpenApiParser.Mappers
                                    requestBodySchemaExample != null ? MapOpenApiAnyToJToken(requestBodySchemaExample) :
                                    MapSchemaToObject(requestBodySchema);
 
-                requestModelBody = MapRequestBody(requestBodyMapped);
+                requestBodyModel = MapRequestBody(requestBodyMapped);
             }
 
             if (!int.TryParse(response.Key, out var httpStatusCode))
@@ -90,7 +90,7 @@ namespace WireMock.Net.OpenApiParser.Mappers
                     Path = MapBasePath(servers) + MapPathWithParameters(path, pathParameters),
                     Params = MapQueryParameters(queryParameters),
                     Headers = MapRequestHeaders(headers),
-                    Body = requestModelBody
+                    Body = requestBodyModel
                 },
                 Response = new ResponseModel
                 {

--- a/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
+++ b/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
@@ -108,11 +108,11 @@ namespace WireMock.Net.OpenApiParser.Mappers
                 return null;
             }
 
-            BodyModel bodyRequestModel = new BodyModel();
-            bodyRequestModel.Matcher = new MatcherModel();
-            bodyRequestModel.Matcher.Name = "JsonMatcher";
-            bodyRequestModel.Matcher.Pattern = JsonConvert.SerializeObject(requestBody, Formatting.Indented);
-            return bodyRequestModel;
+            var requestBodyModel = new BodyModel();
+            requestBodyModel.Matcher = new MatcherModel();
+            requestBodyModel.Matcher.Name = "JsonMatcher";
+            requestBodyModel.Matcher.Pattern = JsonConvert.SerializeObject(requestBody, Formatting.Indented);
+            return requestBodyModel;
         }
 
         private bool TryGetContent(IDictionary<string, OpenApiMediaType> contents, out OpenApiMediaType openApiMediaType, out string contentType)

--- a/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
+++ b/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
@@ -59,7 +59,7 @@ namespace WireMock.Net.OpenApiParser.Mappers
                                    responseSchemaExample != null ? MapOpenApiAnyToJToken(responseSchemaExample) :
                                    MapSchemaToObject(responseSchema);
 
-            BodyModel bodyRequestModel = new BodyModel();
+            BodyModel requestModeloBody = new BodyModel();
             if (operation.RequestBody != null && operation.RequestBody.Content != null)
             {
                 var requestBody = operation.RequestBody.Content.First();
@@ -67,12 +67,11 @@ namespace WireMock.Net.OpenApiParser.Mappers
                 var requestBodyExample = requestBody.Value?.Example;
                 var requestBodySchemaExample = requestBody.Value?.Schema?.Example;
 
-                var requetBodyBuilded = requestBodyExample != null ? MapOpenApiAnyToJToken(requestBodyExample) :
+                var requestBodyMapped = requestBodyExample != null ? MapOpenApiAnyToJToken(requestBodyExample) :
                                    requestBodySchemaExample != null ? MapOpenApiAnyToJToken(requestBodySchemaExample) :
                                    MapSchemaToObject(requestBodySchema);
 
-                bodyRequestModel = MapRequestBody(requetBodyBuilded);
-
+                requestModeloBody = MapRequestBody(requestBodyMapped);
             }
 
             if (!int.TryParse(response.Key, out var httpStatusCode))
@@ -89,7 +88,7 @@ namespace WireMock.Net.OpenApiParser.Mappers
                     Path = MapBasePath(servers) + MapPathWithParameters(path, pathParameters),
                     Params = MapQueryParameters(queryParameters),
                     Headers = MapRequestHeaders(headers),
-                    Body = bodyRequestModel
+                    Body = requestModeloBody
                 },
                 Response = new ResponseModel
                 {

--- a/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
+++ b/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
@@ -62,10 +62,12 @@ namespace WireMock.Net.OpenApiParser.Mappers
             BodyModel requestModeloBody = new BodyModel();
             if (operation.RequestBody != null && operation.RequestBody.Content != null)
             {
-                var requestBody = operation.RequestBody.Content.First();
+                var request = operation.RequestBody.Content;
+                TryGetContent(request, out OpenApiMediaType requestContent, out string requestContentType);
+
                 var requestBodySchema = operation.RequestBody.Content.First().Value?.Schema;
-                var requestBodyExample = requestBody.Value?.Example;
-                var requestBodySchemaExample = requestBody.Value?.Schema?.Example;
+                var requestBodyExample = requestContent.Example;
+                var requestBodySchemaExample = requestContent.Schema?.Example;
 
                 var requestBodyMapped = requestBodyExample != null ? MapOpenApiAnyToJToken(requestBodyExample) :
                                    requestBodySchemaExample != null ? MapOpenApiAnyToJToken(requestBodySchemaExample) :


### PR DESCRIPTION
Hello @StefH,

I'm trying to add the support to request body, I'm following the same logic used in the response, I'm facing a problem when I try to use `BodyAsJson` in the `RequestModel` 'cause it does not exist, I'm using `Body` but it does not work as I expected, could you have idea why it is happening? 

I appreciate your help.