### PR TITLE
Add wildcard matching support for path and header parameters in OpenAPI

### DIFF
--- a/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
+++ b/src/WireMock.Net.OpenApiParser/Mappers/OpenApiPathsMapper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -332,8 +332,8 @@ namespace WireMock.Net.OpenApiParser.Mappers
                     {
                         new MatcherModel
                         {
-                            Name = "ExactMatcher",
-                            Pattern = GetDefaultValueAsStringForSchemaType(qp.Schema)
+                            Name = GetMatcherName(_settings.HeaderPatternToUse),
+                            Pattern = GetExampleValue(qp.Schema, _settings.HeaderPatternToUse)
                         }
                     }
                 })
@@ -352,8 +352,8 @@ namespace WireMock.Net.OpenApiParser.Mappers
                     {
                         new MatcherModel
                         {
-                            Name = "ExactMatcher",
-                            Pattern = GetDefaultValueAsStringForSchemaType(qp.Schema)
+                            Name = GetMatcherName(_settings.HeaderPatternToUse),
+                            Pattern = GetExampleValue(qp.Schema, _settings.HeaderPatternToUse)
                         }
                     }
                 })
@@ -385,6 +385,18 @@ namespace WireMock.Net.OpenApiParser.Mappers
 
                 default:
                     return "*";
+            }
+        }
+
+        private string GetMatcherName(ExampleValueType type)
+        {
+            switch (type)
+            {
+                case ExampleValueType.Value:
+                    return "ExactMatcher";
+
+                default:
+                    return "WildcardMatcher";
             }
         }
     }


### PR DESCRIPTION
Hi,
I'm using WireMock.Net with an OpenAPI parser, but when generating the mappings the behavior of matching headers and parameters in the query string is set permanently (ExactMatcher). I have a proposal to use the settings to control the matching behavior:
```c#
var settings = new WireMockOpenApiParserSettings
{
     PathPatternToUse = ExampleValueType.Wildcard,
     HeaderPatternToUse = ExampleValueType.Wildcard
};
```
However, I am not sure if these two parameters can be used for this purpose :) I am asking for your opinion and if it is OK, please include it in the solution.
