### PR TITLE
Provide open api schema to dynamic examples generator so you can generate accurate data

### DIFF
--- a/examples/WireMock.Net.OpenApiParser.ConsoleApp/DynamicDataGeneration.cs
+++ b/examples/WireMock.Net.OpenApiParser.ConsoleApp/DynamicDataGeneration.cs
@@ -1,0 +1,48 @@
+using System;
+using Microsoft.OpenApi.Models;
+using RandomDataGenerator.FieldOptions;
+using RandomDataGenerator.Randomizers;
+using WireMock.Net.OpenApiParser.Settings;
+
+namespace WireMock.Net.OpenApiParser.ConsoleApp
+{
+
+    public class DynamicDataGeneration : IWireMockOpenApiParserExampleValues
+    {
+
+        public bool Boolean { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBoolean()).Generate() ?? true; } set { } }
+
+        public int Integer { get { return RandomizerFactory.GetRandomizer(new FieldOptionsInteger()).Generate() ?? 42; } set { } }
+
+        public float Float { get { return RandomizerFactory.GetRandomizer(new FieldOptionsFloat()).Generate() ?? 4.2f; } set { } }
+
+        public double Double { get { return RandomizerFactory.GetRandomizer(new FieldOptionsDouble()).Generate() ?? 4.2d; } set { } }
+
+        public Func<DateTime> Date { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow.Date; } set { } }
+
+        public Func<DateTime> DateTime { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow; } set { } }
+
+        public byte[] Bytes { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBytes()).Generate(); } set { } }
+
+        public object Object { get; set; } = "example-object";
+
+        public string String
+        {
+            get
+            {
+                //Since you have your Schema, you can get if max-lenght is set. You can generate accurate examples with this settings
+                var maxLength = this.Schema.MaxLength ?? 9;
+
+                return RandomizerFactory.GetRandomizer(new FieldOptionsTextRegex
+                {
+                    Pattern = $"[0-9A-Z]{{{maxLength}}}"
+                }).Generate() ?? "example-string";
+            }
+            set { }
+        }
+
+        public OpenApiSchema Schema { get; set; } = new OpenApiSchema();
+
+    }
+
+}

--- a/examples/WireMock.Net.OpenApiParser.ConsoleApp/DynamicDataGeneration.cs
+++ b/examples/WireMock.Net.OpenApiParser.ConsoleApp/DynamicDataGeneration.cs
@@ -6,25 +6,9 @@ using WireMock.Net.OpenApiParser.Settings;
 
 namespace WireMock.Net.OpenApiParser.ConsoleApp
 {
-    public class DynamicDataGeneration : IWireMockOpenApiParserExampleValues
+    public class DynamicDataGeneration : WireMockOpenApiParserDynamicExampleValues
     {
-        public bool Boolean { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBoolean()).Generate() ?? true; } set { } }
-
-        public int Integer { get { return RandomizerFactory.GetRandomizer(new FieldOptionsInteger()).Generate() ?? 42; } set { } }
-
-        public float Float { get { return RandomizerFactory.GetRandomizer(new FieldOptionsFloat()).Generate() ?? 4.2f; } set { } }
-
-        public double Double { get { return RandomizerFactory.GetRandomizer(new FieldOptionsDouble()).Generate() ?? 4.2d; } set { } }
-
-        public Func<DateTime> Date { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow.Date; } set { } }
-
-        public Func<DateTime> DateTime { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow; } set { } }
-
-        public byte[] Bytes { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBytes()).Generate(); } set { } }
-
-        public object Object { get; set; } = "example-object";
-
-        public string String
+        public override string String
         {
             get
             {
@@ -38,6 +22,5 @@ namespace WireMock.Net.OpenApiParser.ConsoleApp
             }
             set { }
         }
-        public OpenApiSchema Schema { get; set; } = new OpenApiSchema();
     }
 }

--- a/examples/WireMock.Net.OpenApiParser.ConsoleApp/DynamicDataGeneration.cs
+++ b/examples/WireMock.Net.OpenApiParser.ConsoleApp/DynamicDataGeneration.cs
@@ -6,10 +6,8 @@ using WireMock.Net.OpenApiParser.Settings;
 
 namespace WireMock.Net.OpenApiParser.ConsoleApp
 {
-
     public class DynamicDataGeneration : IWireMockOpenApiParserExampleValues
     {
-
         public bool Boolean { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBoolean()).Generate() ?? true; } set { } }
 
         public int Integer { get { return RandomizerFactory.GetRandomizer(new FieldOptionsInteger()).Generate() ?? 42; } set { } }
@@ -40,9 +38,6 @@ namespace WireMock.Net.OpenApiParser.ConsoleApp
             }
             set { }
         }
-
         public OpenApiSchema Schema { get; set; } = new OpenApiSchema();
-
     }
-
 }

--- a/examples/WireMock.Net.OpenApiParser.ConsoleApp/OpenApiFiles/Swagger_Customer_V2.0.json
+++ b/examples/WireMock.Net.OpenApiParser.ConsoleApp/OpenApiFiles/Swagger_Customer_V2.0.json
@@ -1,0 +1,73 @@
+{
+    "swagger": "2.0",
+    "info": {
+        "title": "customer",
+        "description": "It contains basic customer actions.",
+        "version": "v1"
+    },
+    "host": "localhost",
+    "basePath": "/v1/customer/",
+    "schemes": [
+        "https"
+    ],
+    "paths": {
+        "/": {
+            "get": {
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "parameters": [
+                    {
+                        "name": "Correlation-Id",
+                        "required": true,
+                        "in": "header",
+                        "type": "string",
+                        "maxLength": 3
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "",
+                        "x-amf-mediaType": "application/json",
+                        "schema": {
+                            "$ref": "#/definitions/ResponseCustmer"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "definitions": {
+        "ResponseCustmer": {
+
+            "type": "object",
+            "additionalProperties": true,
+            "required": [
+                "first-name",
+                "last-name",
+                "status",
+                "interest"
+            ],
+            "properties": {
+                "first-name": {
+                    "type": "string"
+                },
+                "last-name": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string",
+                    "maxLength": 2
+                },
+                "interest": {
+                    "type": "string",
+                    "maxLength": 45
+                }
+            }
+        }
+    }
+}
+

--- a/examples/WireMock.Net.OpenApiParser.ConsoleApp/Program.cs
+++ b/examples/WireMock.Net.OpenApiParser.ConsoleApp/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using Microsoft.OpenApi.Readers;
+using Newtonsoft.Json;
 
 namespace WireMock.Net.OpenApiParser.ConsoleApp
 {
@@ -7,6 +9,24 @@ namespace WireMock.Net.OpenApiParser.ConsoleApp
     {
         private const string Folder = "OpenApiFiles";
         static void Main(string[] args)
+        {
+
+            //RunOthersOpenApiParserExample();
+
+            RunMockServerWithDynamicExampleGeneration();
+        }
+
+        private static void RunMockServerWithDynamicExampleGeneration() {
+
+            //Run your mocking framework specifieing youur Example Values generator class.
+            var serverCustomer_V2_json = Run.RunServer(Path.Combine(Folder, "Swagger_Customer_V2.0.json"), "http://localhost:8090/", true, new DynamicDataGeneration(), Types.ExampleValueType.Value, Types.ExampleValueType.Value);
+            Console.WriteLine("Press any key to stop the servers");
+
+            Console.ReadKey();
+            serverCustomer_V2_json.Stop();
+        }
+
+        private static void RunOthersOpenApiParserExample()
         {
             var serverOpenAPIExamples = Run.RunServer(Path.Combine(Folder, "openAPIExamples.yaml"), "https://localhost:9091/");
             var serverPetstore_V2_json = Run.RunServer(Path.Combine(Folder, "Swagger_Petstore_V2.0.json"), "https://localhost:9092/");

--- a/examples/WireMock.Net.OpenApiParser.ConsoleApp/Program.cs
+++ b/examples/WireMock.Net.OpenApiParser.ConsoleApp/Program.cs
@@ -10,14 +10,12 @@ namespace WireMock.Net.OpenApiParser.ConsoleApp
         private const string Folder = "OpenApiFiles";
         static void Main(string[] args)
         {
-
             //RunOthersOpenApiParserExample();
 
             RunMockServerWithDynamicExampleGeneration();
         }
 
         private static void RunMockServerWithDynamicExampleGeneration() {
-
             //Run your mocking framework specifieing youur Example Values generator class.
             var serverCustomer_V2_json = Run.RunServer(Path.Combine(Folder, "Swagger_Customer_V2.0.json"), "http://localhost:8090/", true, new DynamicDataGeneration(), Types.ExampleValueType.Value, Types.ExampleValueType.Value);
             Console.WriteLine("Press any key to stop the servers");

--- a/examples/WireMock.Net.OpenApiParser.ConsoleApp/Run.cs
+++ b/examples/WireMock.Net.OpenApiParser.ConsoleApp/Run.cs
@@ -13,27 +13,29 @@ namespace WireMock.Net.OpenApiParser.ConsoleApp
 {
     public static class Run
     {
-        public static WireMockServer RunServer(string path, string url, bool dynamicExamples = true)
+        public static WireMockServer RunServer(string path, string url, bool dynamicExamples = true, IWireMockOpenApiParserExampleValues examplesValuesGenerator =  null, ExampleValueType pathPatternToUse = ExampleValueType.Wildcard, ExampleValueType headerPatternToUse = ExampleValueType.Wildcard)
         {
             var server = WireMockServer.Start(new WireMockServerSettings
             {
                 AllowCSharpCodeMatcher = true,
                 Urls = new[] { url },
                 StartAdminInterface = true,
-                ReadStaticMappings = false,
+                ReadStaticMappings = true,
                 WatchStaticMappings = false,
                 WatchStaticMappingsInSubdirectories = false,
                 Logger = new WireMockConsoleLogger()
+
             });
             Console.WriteLine("WireMockServer listening at {0}", string.Join(",", server.Urls));
 
-            server.SetBasicAuthentication("a", "b");
+            //server.SetBasicAuthentication("a", "b");
 
             var settings = new WireMockOpenApiParserSettings
             {
                 DynamicExamples = dynamicExamples,
-                PathPatternToUse = ExampleValueType.Wildcard,
-                HeaderPatternToUse = ExampleValueType.Wildcard
+                ExampleValues = examplesValuesGenerator,
+                PathPatternToUse = pathPatternToUse,
+                HeaderPatternToUse = headerPatternToUse,
             };
 
             server.WithMappingFromOpenApiFile(path, settings, out var diag);

--- a/examples/WireMock.Net.OpenApiParser.ConsoleApp/Run.cs
+++ b/examples/WireMock.Net.OpenApiParser.ConsoleApp/Run.cs
@@ -24,8 +24,8 @@ namespace WireMock.Net.OpenApiParser.ConsoleApp
                 WatchStaticMappings = false,
                 WatchStaticMappingsInSubdirectories = false,
                 Logger = new WireMockConsoleLogger()
-
             });
+
             Console.WriteLine("WireMockServer listening at {0}", string.Join(",", server.Urls));
 
             //server.SetBasicAuthentication("a", "b");

--- a/examples/WireMock.Net.OpenApiParser.ConsoleApp/WireMock.Net.OpenApiParser.ConsoleApp.csproj
+++ b/examples/WireMock.Net.OpenApiParser.ConsoleApp/WireMock.Net.OpenApiParser.ConsoleApp.csproj
@@ -36,6 +36,9 @@
     <None Update="petstore.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="OpenApiFiles\Swagger_Customer_V2.0.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.OpenApi.Models;
 
 namespace WireMock.Net.OpenApiParser.Settings
 {
@@ -48,5 +49,10 @@ namespace WireMock.Net.OpenApiParser.Settings
         /// An example value for a String.
         /// </summary>
         string String { get; set; }
+
+        /// <summary>
+        /// OpenApi Schema to generate dynamic examples more accurate
+        /// </summary>
+        OpenApiSchema SchemaExample { get; set; }
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/IWireMockOpenApiParserExampleValues.cs
@@ -53,6 +53,6 @@ namespace WireMock.Net.OpenApiParser.Settings
         /// <summary>
         /// OpenApi Schema to generate dynamic examples more accurate
         /// </summary>
-        OpenApiSchema SchemaExample { get; set; }
+        OpenApiSchema Schema { get; set; }
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.OpenApi.Models;
 using RandomDataGenerator.FieldOptions;
 using RandomDataGenerator.Randomizers;
 
@@ -27,5 +28,7 @@ namespace WireMock.Net.OpenApiParser.Settings
         public object Object { get; set; } = "example-object";
         /// <inheritdoc />
         public string String { get { return RandomizerFactory.GetRandomizer(new FieldOptionsTextRegex { Pattern = @"^[0-9]{2}[A-Z]{5}[0-9]{2}" }).Generate() ?? "example-string"; } set { } }
+        /// <inheritdoc />
+        public OpenApiSchema SchemaExample { get; set; }
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
@@ -29,6 +29,6 @@ namespace WireMock.Net.OpenApiParser.Settings
         /// <inheritdoc />
         public string String { get { return RandomizerFactory.GetRandomizer(new FieldOptionsTextRegex { Pattern = @"^[0-9]{2}[A-Z]{5}[0-9]{2}" }).Generate() ?? "example-string"; } set { } }
         /// <inheritdoc />
-        public OpenApiSchema SchemaExample { get; set; }
+        public OpenApiSchema Schema { get; set; }
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserDynamicExampleValues.cs
@@ -11,24 +11,24 @@ namespace WireMock.Net.OpenApiParser.Settings
     public class WireMockOpenApiParserDynamicExampleValues : IWireMockOpenApiParserExampleValues
     {
         /// <inheritdoc />
-        public bool Boolean { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBoolean()).Generate() ?? true; } set { } }
+        public virtual bool Boolean { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBoolean()).Generate() ?? true; } set { } }
         /// <inheritdoc />
-        public int Integer { get { return RandomizerFactory.GetRandomizer(new FieldOptionsInteger()).Generate() ?? 42; } set { } }
+        public virtual int Integer { get { return RandomizerFactory.GetRandomizer(new FieldOptionsInteger()).Generate() ?? 42; } set { } }
         /// <inheritdoc />
-        public float Float { get { return RandomizerFactory.GetRandomizer(new FieldOptionsFloat()).Generate() ?? 4.2f; } set { } }
+        public virtual float Float { get { return RandomizerFactory.GetRandomizer(new FieldOptionsFloat()).Generate() ?? 4.2f; } set { } }
         /// <inheritdoc />
-        public double Double { get { return RandomizerFactory.GetRandomizer(new FieldOptionsDouble()).Generate() ?? 4.2d; } set { } }
+        public virtual double Double { get { return RandomizerFactory.GetRandomizer(new FieldOptionsDouble()).Generate() ?? 4.2d; } set { } }
         /// <inheritdoc />
-        public Func<DateTime> Date { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow.Date; } set { } }
+        public virtual Func<DateTime> Date { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow.Date; } set { } }
         /// <inheritdoc />
-        public Func<DateTime> DateTime { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow; } set { } }
+        public virtual Func<DateTime> DateTime { get { return () => RandomizerFactory.GetRandomizer(new FieldOptionsDateTime()).Generate() ?? System.DateTime.UtcNow; } set { } }
         /// <inheritdoc />
-        public byte[] Bytes { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBytes()).Generate(); } set { } }
+        public virtual byte[] Bytes { get { return RandomizerFactory.GetRandomizer(new FieldOptionsBytes()).Generate(); } set { } }
         /// <inheritdoc />
-        public object Object { get; set; } = "example-object";
+        public virtual object Object { get; set; } = "example-object";
         /// <inheritdoc />
-        public string String { get { return RandomizerFactory.GetRandomizer(new FieldOptionsTextRegex { Pattern = @"^[0-9]{2}[A-Z]{5}[0-9]{2}" }).Generate() ?? "example-string"; } set { } }
+        public virtual string String { get { return RandomizerFactory.GetRandomizer(new FieldOptionsTextRegex { Pattern = @"^[0-9]{2}[A-Z]{5}[0-9]{2}" }).Generate() ?? "example-string"; } set { } }
         /// <inheritdoc />
-        public OpenApiSchema Schema { get; set; }
+        public virtual OpenApiSchema Schema { get; set; }
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.OpenApi.Models;
 
 namespace WireMock.Net.OpenApiParser.Settings
 {
@@ -25,5 +26,7 @@ namespace WireMock.Net.OpenApiParser.Settings
         public object Object { get; set; } = "example-object";
         /// <inheritdoc />
         public string String { get; set; } = "example-string";
+        /// <inheritdoc />
+        public OpenApiSchema SchemaExample { get; set; }
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
@@ -9,24 +9,24 @@ namespace WireMock.Net.OpenApiParser.Settings
     public class WireMockOpenApiParserExampleValues : IWireMockOpenApiParserExampleValues
     {
         /// <inheritdoc />
-        public bool Boolean { get; set; } = true;
+        public virtual bool Boolean { get; set; } = true;
         /// <inheritdoc />
-        public int Integer { get; set; } = 42;
+        public virtual int Integer { get; set; } = 42;
         /// <inheritdoc />
-        public float Float { get; set; } = 4.2f;
+        public virtual float Float { get; set; } = 4.2f;
         /// <inheritdoc />
-        public double Double { get; set; } = 4.2d;
+        public virtual double Double { get; set; } = 4.2d;
         /// <inheritdoc />
-        public Func<DateTime> Date { get; set; } = () => System.DateTime.UtcNow.Date;
+        public virtual Func<DateTime> Date { get; set; } = () => System.DateTime.UtcNow.Date;
         /// <inheritdoc />
-        public Func<DateTime> DateTime { get; set; } = () => System.DateTime.UtcNow;
+        public virtual Func<DateTime> DateTime { get; set; } = () => System.DateTime.UtcNow;
         /// <inheritdoc />
-        public byte[] Bytes { get; set; } = { 48, 49, 50 };
+        public virtual byte[] Bytes { get; set; } = { 48, 49, 50 };
         /// <inheritdoc />
-        public object Object { get; set; } = "example-object";
+        public virtual object Object { get; set; } = "example-object";
         /// <inheritdoc />
-        public string String { get; set; } = "example-string";
+        public virtual string String { get; set; } = "example-string";
         /// <inheritdoc />
-        public OpenApiSchema Schema { get; set; } = new OpenApiSchema();
+        public virtual OpenApiSchema Schema { get; set; } = new OpenApiSchema();
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
+++ b/src/WireMock.Net.OpenApiParser/Settings/WireMockOpenApiParserExampleValues.cs
@@ -27,6 +27,6 @@ namespace WireMock.Net.OpenApiParser.Settings
         /// <inheritdoc />
         public string String { get; set; } = "example-string";
         /// <inheritdoc />
-        public OpenApiSchema SchemaExample { get; set; }
+        public OpenApiSchema Schema { get; set; } = new OpenApiSchema();
     }
 }

--- a/src/WireMock.Net.OpenApiParser/Utils/ExampleValueGenerator.cs
+++ b/src/WireMock.Net.OpenApiParser/Utils/ExampleValueGenerator.cs
@@ -36,7 +36,7 @@ namespace WireMock.Net.OpenApiParser.Utils
             var schemaExample = schema?.Example;
             var schemaEnum = GetRandomEnumValue(schema?.Enum);
 
-            _settings.ExampleValues.SchemaExample = schema;
+            _settings.ExampleValues.Schema = schema;
 
             switch (schema?.GetSchemaType())
             {

--- a/src/WireMock.Net.OpenApiParser/Utils/ExampleValueGenerator.cs
+++ b/src/WireMock.Net.OpenApiParser/Utils/ExampleValueGenerator.cs
@@ -36,6 +36,8 @@ namespace WireMock.Net.OpenApiParser.Utils
             var schemaExample = schema?.Example;
             var schemaEnum = GetRandomEnumValue(schema?.Enum);
 
+            _settings.ExampleValues.SchemaExample = schema;
+
             switch (schema?.GetSchemaType())
             {
                 case SchemaType.Boolean:


### PR DESCRIPTION
@StefH  Having ope api Schema we can use settings like max-length in case of a string to generate more accurate mock data when you implement your dynamic examples