### PR TITLE
Change nuget to package reference for WireMock.Net.Console.Net472.Cla…

### DIFF
--- a/examples/WireMock.Net.Console.Net452.Classic/MainApp.cs
+++ b/examples/WireMock.Net.Console.Net452.Classic/MainApp.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using WireMock.Logging;
 using WireMock.Matchers;
+using WireMock.Models;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -575,6 +576,38 @@ namespace WireMock.Net.ConsoleApplication
                         StatusCode = code
                     };
                 }));
+
+            server.Given(Request.Create().WithPath(new WildcardMatcher("/multi-webhook", true)).UsingPost())
+                .WithWebhook(new Webhook
+                {
+                    Request = new WebhookRequest
+                    {
+                        Url = "https://any:12345/foo1",
+                        Method = "post",
+                        BodyData = new BodyData
+                        {
+                            BodyAsString = "OK 1!", DetectedBodyType = BodyType.String
+                        },
+                        Delay = 1000
+                    }
+                })
+                .WithWebhook(new Webhook
+                {
+                    Request = new WebhookRequest
+                    {
+                        Url = "https://localhost:12345/foo2",
+                        Method = "post",
+                        BodyData = new BodyData
+                        {
+                            BodyAsString = "OK 2!",
+                            DetectedBodyType = BodyType.String
+                        },
+                        MinimumRandomDelay = 3000,
+                        MaximumRandomDelay = 7000
+                    }
+                })
+                .WithWebhookFireAndForget(true)
+                .RespondWith(Response.Create().WithBody("a-response"));
 
             System.Console.WriteLine(JsonConvert.SerializeObject(server.MappingModels, Formatting.Indented));
 

--- a/examples/WireMock.Net.Console.Net472.Classic/WireMock.Net.Console.Net472.Classic.csproj
+++ b/examples/WireMock.Net.Console.Net472.Classic/WireMock.Net.Console.Net472.Classic.csproj
@@ -342,15 +342,6 @@
     <Reference Include="TinyMapper, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\TinyMapper.3.0.3\lib\net40\TinyMapper.dll</HintPath>
     </Reference>
-    <Reference Include="WireMock.Net, Version=1.5.3.0, Culture=neutral, PublicKeyToken=c8d65537854e1f03, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WireMock.Net.1.5.3\lib\net461\WireMock.Net.dll</HintPath>
-    </Reference>
-    <Reference Include="WireMock.Net.Abstractions, Version=1.5.3.0, Culture=neutral, PublicKeyToken=c8d65537854e1f03, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WireMock.Net.Abstractions.1.5.3\lib\net451\WireMock.Net.Abstractions.dll</HintPath>
-    </Reference>
-    <Reference Include="WireMock.Org.Abstractions, Version=1.5.3.0, Culture=neutral, PublicKeyToken=c8d65537854e1f03, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\WireMock.Org.Abstractions.1.5.3\lib\net45\WireMock.Org.Abstractions.dll</HintPath>
-    </Reference>
     <Reference Include="XPath2, Version=1.1.3.0, Culture=neutral, PublicKeyToken=463c6d7fb740c7e5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\XPath2.1.1.3\lib\net452\XPath2.dll</HintPath>
     </Reference>
@@ -387,6 +378,16 @@
     </None>
     <None Include="App.config" />
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\WireMock.Net.Abstractions\WireMock.Net.Abstractions.csproj">
+      <Project>{b6269aac-170a-4346-8b9a-579ded3d9a94}</Project>
+      <Name>WireMock.Net.Abstractions</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\src\WireMock.Net\WireMock.Net.csproj">
+      <Project>{d3804228-91f4-4502-9595-39584e5a01ad}</Project>
+      <Name>WireMock.Net</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/examples/WireMock.Net.Console.Net472.Classic/packages.config
+++ b/examples/WireMock.Net.Console.Net472.Classic/packages.config
@@ -147,9 +147,6 @@
   <package id="System.Threading.Tasks.Extensions" version="4.5.1" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="TinyMapper" version="3.0.3" targetFramework="net472" />
-  <package id="WireMock.Net" version="1.5.3" targetFramework="net472" />
-  <package id="WireMock.Net.Abstractions" version="1.5.3" targetFramework="net472" />
-  <package id="WireMock.Org.Abstractions" version="1.5.3" targetFramework="net472" />
   <package id="XPath2" version="1.1.3" targetFramework="net472" />
   <package id="XPath2.Extensions" version="1.1.3" targetFramework="net472" />
 </packages>

--- a/src/WireMock.Net.Abstractions/Admin/Mappings/MappingModel.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/MappingModel.cs
@@ -74,4 +74,9 @@ public class MappingModel
     /// The Webhooks.
     /// </summary>
     public WebhookModel[]? Webhooks { get; set; }
+
+    /// <summary>
+    /// Fire and forget for webhooks.
+    /// </summary>
+    public bool? UseWebhooksFireAndForget { get; set; }
 }

--- a/src/WireMock.Net.Abstractions/Admin/Mappings/WebhookRequestModel.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/WebhookRequestModel.cs
@@ -49,11 +49,6 @@ public class WebhookRequestModel
     public string? TransformerReplaceNodeOptions { get; set; }
 
     /// <summary>
-    /// Use Fire and Forget (do not wait on result). Default value is false.
-    /// </summary>
-    public bool? UseFireAndForget { get; set; }
-
-    /// <summary>
     /// Gets or sets the delay in milliseconds.
     /// </summary>
     public int? Delay { get; set; }

--- a/src/WireMock.Net.Abstractions/Models/IWebhookRequest.cs
+++ b/src/WireMock.Net.Abstractions/Models/IWebhookRequest.cs
@@ -45,11 +45,6 @@ public interface IWebhookRequest
     ReplaceNodeOptions TransformerReplaceNodeOptions { get; set; }
 
     /// <summary>
-    /// Use Fire and Forget (do not wait on result). Default value is false.
-    /// </summary>
-    bool? UseFireAndForget { get; set; }
-
-    /// <summary>
     /// Gets or sets the delay in milliseconds.
     /// </summary>
     int? Delay { get; set; }

--- a/src/WireMock.Net/Http/WebhookSender.cs
+++ b/src/WireMock.Net/Http/WebhookSender.cs
@@ -102,32 +102,7 @@ internal class WebhookSender
         // Call the URL
         var sendTask = client.SendAsync(httpRequestMessage);
 
-        if (webhookRequest.UseFireAndForget == true)
-        {
-            try
-            {
-                FireAndForget(sendTask);
-            }
-            catch
-            {
-                // Ignore
-            }
-            return HttpResponseMessageOk;
-        }
-
         return await SendAsync(sendTask);
-    }
-
-    private static async void FireAndForget(Task sendTask)
-    {
-        try
-        {
-            await sendTask;
-        }
-        catch
-        {
-            // Ignore
-        }
     }
 
     private static async Task<HttpResponseMessage> SendAsync(Task<HttpResponseMessage> sendTask)

--- a/src/WireMock.Net/IMapping.cs
+++ b/src/WireMock.Net/IMapping.cs
@@ -113,6 +113,11 @@ public interface IMapping
     IWebhook[]? Webhooks { get; }
 
     /// <summary>
+    /// 
+    /// </summary>
+    public bool? UseWebhooksFireAndForget { get; set; }
+
+    /// <summary>
     /// ProvideResponseAsync
     /// </summary>
     /// <param name="requestMessage">The request message.</param>

--- a/src/WireMock.Net/Mapping.cs
+++ b/src/WireMock.Net/Mapping.cs
@@ -64,6 +64,9 @@ public class Mapping : IMapping
     public IWebhook[]? Webhooks { get; }
 
     /// <inheritdoc />
+    public bool? UseWebhooksFireAndForget { get; set; }
+
+    /// <inheritdoc />
     public ITimeSettings? TimeSettings { get; }
 
     /// <summary>
@@ -82,6 +85,7 @@ public class Mapping : IMapping
     /// <param name="nextState">The next state which will occur after the current mapping execution. [Optional]</param>
     /// <param name="stateTimes">Only when the current state is executed this number, the next state which will occur. [Optional]</param>
     /// <param name="webhooks">The Webhooks. [Optional]</param>
+    /// <param name="useWebhooksFireAndForget">Use Fire and Forget for any defined webhooks</param>
     /// <param name="timeSettings">The TimeSettings. [Optional]</param>
     public Mapping(
         Guid guid,
@@ -97,6 +101,7 @@ public class Mapping : IMapping
         string? nextState,
         int? stateTimes,
         IWebhook[]? webhooks,
+        bool? useWebhooksFireAndForget,
         ITimeSettings? timeSettings)
     {
         Guid = guid;
@@ -112,6 +117,7 @@ public class Mapping : IMapping
         NextState = nextState;
         StateTimes = stateTimes;
         Webhooks = webhooks;
+        UseWebhooksFireAndForget = useWebhooksFireAndForget;
         TimeSettings = timeSettings;
     }
 

--- a/src/WireMock.Net/Models/WebhookRequest.cs
+++ b/src/WireMock.Net/Models/WebhookRequest.cs
@@ -31,9 +31,6 @@ public class WebhookRequest : IWebhookRequest
     public ReplaceNodeOptions TransformerReplaceNodeOptions { get; set; }
 
     /// <inheritdoc />
-    public bool? UseFireAndForget { get; set; }
-
-    /// <inheritdoc />
     public int? Delay { get; set; }
 
     /// <inheritdoc />

--- a/src/WireMock.Net/Proxy/ProxyHelper.cs
+++ b/src/WireMock.Net/Proxy/ProxyHelper.cs
@@ -119,6 +119,7 @@ internal class ProxyHelper
             nextState: null,
             stateTimes: null,
             webhooks: null,
+            useWebhooksFireAndForget: null,
             timeSettings: null
         );
     }

--- a/src/WireMock.Net/Serialization/MappingConverter.cs
+++ b/src/WireMock.Net/Serialization/MappingConverter.cs
@@ -43,6 +43,7 @@ internal class MappingConverter
             TimeSettings = TimeSettingsMapper.Map(mapping.TimeSettings),
             Title = mapping.Title,
             Description = mapping.Description,
+            UseWebhooksFireAndForget = mapping.UseWebhooksFireAndForget,
             Priority = mapping.Priority != 0 ? mapping.Priority : null,
             Scenario = mapping.Scenario,
             WhenStateIs = mapping.ExecutionConditionState,

--- a/src/WireMock.Net/Serialization/WebhookMapper.cs
+++ b/src/WireMock.Net/Serialization/WebhookMapper.cs
@@ -20,7 +20,6 @@ internal static class WebhookMapper
             {
                 Url = model.Request.Url,
                 Method = model.Request.Method,
-                UseFireAndForget = model.Request.UseFireAndForget,
                 Delay = model.Request.Delay,
                 MinimumRandomDelay = model.Request.MinimumRandomDelay,
                 MaximumRandomDelay = model.Request.MaximumRandomDelay,
@@ -87,7 +86,6 @@ internal static class WebhookMapper
                 UseTransformer = webhook.Request.UseTransformer,
                 TransformerType = webhook.Request.UseTransformer == true ? webhook.Request.TransformerType.ToString() : null,
                 TransformerReplaceNodeOptions = webhook.Request.TransformerReplaceNodeOptions.ToString(),
-                UseFireAndForget = webhook.Request.UseFireAndForget,
                 Delay = webhook.Request.Delay,
                 MinimumRandomDelay = webhook.Request.MinimumRandomDelay,
                 MaximumRandomDelay = webhook.Request.MaximumRandomDelay,

--- a/src/WireMock.Net/Server/IRespondWithAProvider.cs
+++ b/src/WireMock.Net/Server/IRespondWithAProvider.cs
@@ -124,6 +124,13 @@ namespace WireMock.Server
         IRespondWithAProvider WithWebhook(params IWebhook[] webhooks);
 
         /// <summary>
+        /// Support FireAndForget for any configured Webhooks
+        /// </summary>
+        /// <param name="UseWebhooksFireAndForget"></param>
+        /// <returns></returns>
+        IRespondWithAProvider WithWebhookFireAndForget(bool UseWebhooksFireAndForget);
+
+        /// <summary>
         /// Add a Webhook to call after the response has been generated.
         /// </summary>
         /// <param name="url">The Webhook Url</param>

--- a/src/WireMock.Net/Server/RespondWithAProvider.cs
+++ b/src/WireMock.Net/Server/RespondWithAProvider.cs
@@ -30,6 +30,8 @@ internal class RespondWithAProvider : IRespondWithAProvider
     private readonly WireMockServerSettings _settings;
     private readonly bool _saveToFile;
 
+    private bool _useWebhookFireAndForget = false;
+
     public Guid Guid { get; private set; } = Guid.NewGuid();
 
     public IWebhook[]? Webhooks { get; private set; }
@@ -57,7 +59,7 @@ internal class RespondWithAProvider : IRespondWithAProvider
     /// <param name="provider">The provider.</param>
     public void RespondWith(IResponseProvider provider)
     {
-        _registrationCallback(new Mapping(Guid, _title, _description, _path, _settings, _requestMatcher, provider, _priority, _scenario, _executionConditionState, _nextState, _timesInSameState, Webhooks, TimeSettings), _saveToFile);
+        _registrationCallback(new Mapping(Guid, _title, _description, _path, _settings, _requestMatcher, provider, _priority, _scenario, _executionConditionState, _nextState, _timesInSameState, Webhooks, _useWebhookFireAndForget, TimeSettings), _saveToFile);
     }
 
     /// <inheritdoc />
@@ -229,6 +231,13 @@ internal class RespondWithAProvider : IRespondWithAProvider
                 DetectedBodyTypeFromContentType = BodyType.Json
             };
         }
+
+        return this;
+    }
+
+    public IRespondWithAProvider WithWebhookFireAndForget(bool useWebhooksFireAndForget)
+    {
+        _useWebhookFireAndForget = useWebhooksFireAndForget;
 
         return this;
     }

--- a/test/WireMock.Net.Tests/Owin/WireMockMiddlewareTests.cs
+++ b/test/WireMock.Net.Tests/Owin/WireMockMiddlewareTests.cs
@@ -176,7 +176,7 @@ namespace WireMock.Net.Tests.Owin
             _mappingMock.SetupGet(m => m.Provider).Returns(responseBuilder);
             _mappingMock.SetupGet(m => m.Settings).Returns(settings);
 
-            var newMappingFromProxy = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, settings, Request.Create(), Response.Create(), 0, null, null, null, null, null, null);
+            var newMappingFromProxy = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, settings, Request.Create(), Response.Create(), 0, null, null, null, null, null, false, null);
             _mappingMock.Setup(m => m.ProvideResponseAsync(It.IsAny<RequestMessage>())).ReturnsAsync((new ResponseMessage(), newMappingFromProxy));
 
             var requestBuilder = Request.Create().UsingAnyMethod();
@@ -230,7 +230,7 @@ namespace WireMock.Net.Tests.Owin
             _mappingMock.SetupGet(m => m.Provider).Returns(responseBuilder);
             _mappingMock.SetupGet(m => m.Settings).Returns(settings);
 
-            var newMappingFromProxy = new Mapping(Guid.NewGuid(), "my-title", "my-description", null, settings, Request.Create(), Response.Create(), 0, null, null, null, null, null, null);
+            var newMappingFromProxy = new Mapping(Guid.NewGuid(), "my-title", "my-description", null, settings, Request.Create(), Response.Create(), 0, null, null, null, null, null, false, null);
             _mappingMock.Setup(m => m.ProvideResponseAsync(It.IsAny<RequestMessage>())).ReturnsAsync((new ResponseMessage(), newMappingFromProxy));
 
             var requestBuilder = Request.Create().UsingAnyMethod();

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.cs
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.cs
@@ -52,7 +52,7 @@ public class MappingConverterTests
                 }
             }
         };
-        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 0, null, null, null, null, webhooks, null);
+        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 0, null, null, null, null, webhooks, false, null);
 
         // Act
         var model = _sut.ToMappingModel(mapping);
@@ -64,6 +64,7 @@ public class MappingConverterTests
         model.Response.BodyAsJsonIndented.Should().BeNull();
         model.Response.UseTransformer.Should().BeNull();
         model.Response.Headers.Should().BeNull();
+        model.UseWebhooksFireAndForget.Should().BeFalse();
 
         model.Webhooks.Should().BeNull();
 
@@ -121,7 +122,7 @@ public class MappingConverterTests
                 }
             }
         };
-        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 0, null, null, null, null, webhooks, null);
+        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 0, null, null, null, null, webhooks, true, null);
 
         // Act
         var model = _sut.ToMappingModel(mapping);
@@ -133,6 +134,7 @@ public class MappingConverterTests
         model.Response.BodyAsJsonIndented.Should().BeNull();
         model.Response.UseTransformer.Should().BeNull();
         model.Response.Headers.Should().BeNull();
+        model.UseWebhooksFireAndForget.Should().BeTrue();
 
         model.Webhook.Should().BeNull();
 
@@ -155,7 +157,7 @@ public class MappingConverterTests
         var description = "my-description";
         var request = Request.Create();
         var response = Response.Create();
-        var mapping = new Mapping(Guid.NewGuid(), title, description, null, _settings, request, response, 0, null, null, null, null, null, null);
+        var mapping = new Mapping(Guid.NewGuid(), title, description, null, _settings, request, response, 0, null, null, null, null, null, false, null);
 
         // Act
         var model = _sut.ToMappingModel(mapping);
@@ -172,7 +174,7 @@ public class MappingConverterTests
         // Assign
         var request = Request.Create();
         var response = Response.Create().WithBodyAsJson(new { x = "x" }).WithTransformer();
-        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, null);
+        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, false, null);
 
         // Act
         var model = _sut.ToMappingModel(mapping);
@@ -198,7 +200,7 @@ public class MappingConverterTests
             End = end,
             TTL = ttl
         };
-        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, timeSettings);
+        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, false, timeSettings);
 
         // Act
         var model = _sut.ToMappingModel(mapping);
@@ -226,7 +228,7 @@ public class MappingConverterTests
         {
             var request = Request.Create();
             var response = Response.Create().WithDelay(test.Delay);
-            var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, string.Empty, _settings, request, response, 42, null, null, null, null, null, null);
+            var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, string.Empty, _settings, request, response, 42, null, null, null, null, null, false, null);
 
             // Act
             var model = _sut.ToMappingModel(mapping);
@@ -244,7 +246,7 @@ public class MappingConverterTests
         var delay = 1000;
         var request = Request.Create();
         var response = Response.Create().WithDelay(delay);
-        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, null);
+        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, false, null);
 
         // Act
         var model = _sut.ToMappingModel(mapping);
@@ -261,7 +263,7 @@ public class MappingConverterTests
         int minimumDelay = 1000;
         var request = Request.Create();
         var response = Response.Create().WithRandomDelay(minimumDelay);
-        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, null);
+        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, false, null);
 
         // Act
         var model = _sut.ToMappingModel(mapping);
@@ -281,7 +283,7 @@ public class MappingConverterTests
         int maximumDelay = 2000;
         var request = Request.Create();
         var response = Response.Create().WithRandomDelay(minimumDelay, maximumDelay);
-        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, null);
+        var mapping = new Mapping(Guid.NewGuid(), string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, false, null);
 
         // Act
         var model = _sut.ToMappingModel(mapping);

--- a/test/WireMock.Net.Tests/Serialization/WebhookMapperTests.cs
+++ b/test/WireMock.Net.Tests/Serialization/WebhookMapperTests.cs
@@ -87,7 +87,6 @@ public class WebhookMapperTests
                     { "x", "y" }
                 },
                 BodyAsJson = new { n = 12345 },
-                UseFireAndForget = true,
                 Delay = 4,
                 MinimumRandomDelay = 5,
                 MaximumRandomDelay = 6
@@ -102,7 +101,6 @@ public class WebhookMapperTests
         result.Request.BodyData!.BodyAsString.Should().BeNull();
         result.Request.BodyData.BodyAsJson.Should().NotBeNull();
         result.Request.BodyData.DetectedBodyType.Should().Be(BodyType.Json);
-        result.Request.UseFireAndForget.Should().BeTrue();
         result.Request.Delay.Should().Be(4);
         result.Request.MinimumRandomDelay.Should().Be(5);
         result.Request.MaximumRandomDelay.Should().Be(6);
@@ -128,7 +126,6 @@ public class WebhookMapperTests
                     DetectedBodyType = BodyType.Json,
                     DetectedBodyTypeFromContentType = BodyType.Json
                 },
-                UseFireAndForget = true,
                 Delay = 4,
                 MinimumRandomDelay = 5,
                 MaximumRandomDelay = 6
@@ -141,7 +138,6 @@ public class WebhookMapperTests
         result.Request.Method.Should().Be("get");
         result.Request.Headers.Should().HaveCount(1);
         result.Request.BodyAsJson.Should().NotBeNull();
-        result.Request.UseFireAndForget.Should().BeTrue();
         result.Request.Delay.Should().Be(4);
         result.Request.MinimumRandomDelay.Should().Be(5);
         result.Request.MaximumRandomDelay.Should().Be(6);


### PR DESCRIPTION
…ssic, move the new FireAndForget into the main mapping, out of individual webhook mappings making it all or nothing, update tests, change Middleware to await or not the firing of all webhooks. Update models as needed.