### PR TITLE
Change some internal classes to public

### DIFF
--- a/src/WireMock.Net/Serialization/JsonSerializationConstants.cs
+++ b/src/WireMock.Net/Serialization/JsonSerializationConstants.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json.Serialization;
 
 namespace WireMock.Serialization;
 
-internal static class JsonSerializationConstants
+public static class JsonSerializationConstants
 {
     public static readonly JsonSerializerSettings JsonSerializerSettingsDefault = new()
     {

--- a/src/WireMock.Net/Util/BodyParser.cs
+++ b/src/WireMock.Net/Util/BodyParser.cs
@@ -11,7 +11,7 @@ using WireMock.Types;
 
 namespace WireMock.Util;
 
-internal static class BodyParser
+public static class BodyParser
 {
     private static readonly Encoding DefaultEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
     private static readonly Encoding[] SupportedBodyAsStringEncodingForMultipart = { DefaultEncoding, Encoding.ASCII };

--- a/src/WireMock.Net/Util/BodyParserSettings.cs
+++ b/src/WireMock.Net/Util/BodyParserSettings.cs
@@ -2,7 +2,7 @@ using System.IO;
 
 namespace WireMock.Util;
 
-internal class BodyParserSettings
+public class BodyParserSettings
 {
     public Stream Stream { get; set; } = null!;
 


### PR DESCRIPTION
Hello, 

I am using WireMock.Net in a project and I wanted to add some changes and see with you if it was possible. 
We are using WireMock.Net to mock requests and reuse mappings for JMeter tests.  I can't use the recording process that is already in place because its a proxy . We prefer that the application make the call rather than WireMock.Net. So to use what have been done and stay up to date I wanted to change some classes :
- **_JsonSerializationConstants_**
- **_BodyParser_**
- _**BodyParserSettings**_
Those classes are internal and I wanted to put them public. That way I can use WireMock.Net in the project.

Thank you for your answer.

