### PR TITLE
Fix C# mapping code generator for header names

### DIFF
--- a/src/WireMock.Net/Serialization/MappingConverter.cs
+++ b/src/WireMock.Net/Serialization/MappingConverter.cs
@@ -129,7 +129,7 @@ internal class MappingConverter
         {
             foreach (var header in response.ResponseMessage.Headers)
             {
-                sb.AppendLine($"        .WithHeader(\"{header.Key})\", {ToValueArguments(header.Value.ToArray())})");
+                sb.AppendLine($"        .WithHeader(\"{header.Key}\", {ToValueArguments(header.Value.ToArray())})");
             }
         }
 

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsFalse.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsFalse.verified.txt
@@ -11,7 +11,7 @@
     .WithGuid("8e7b9ab7-e18e-4502-8bc9-11e6679811cc")
     .WithProbability(0.3)
     .RespondWith(Response.Create()
-        .WithHeader("Keep-Alive)", "test")
+        .WithHeader("Keep-Alive", "test")
         .WithBody("bbb")
         .WithDelay(12345)
         .WithTransformer()

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsTrue.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsTrue.verified.txt
@@ -12,7 +12,7 @@ builder
     .WithGuid("8e7b9ab7-e18e-4502-8bc9-11e6679811cc")
     .WithProbability(0.3)
     .RespondWith(Response.Create()
-        .WithHeader("Keep-Alive)", "test")
+        .WithHeader("Keep-Alive", "test")
         .WithBody("bbb")
         .WithDelay(12345)
         .WithTransformer()

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsFalse.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsFalse.verified.txt
@@ -11,7 +11,7 @@
     .WithGuid("8e7b9ab7-e18e-4502-8bc9-11e6679811cc")
     .WithProbability(0.3)
     .RespondWith(Response.Create()
-        .WithHeader("Keep-Alive)", "test")
+        .WithHeader("Keep-Alive", "test")
         .WithBody("bbb")
         .WithDelay(12345)
         .WithTransformer()

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsTrue.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsTrue.verified.txt
@@ -12,7 +12,7 @@ server
     .WithGuid("8e7b9ab7-e18e-4502-8bc9-11e6679811cc")
     .WithProbability(0.3)
     .RespondWith(Response.Create()
-        .WithHeader("Keep-Alive)", "test")
+        .WithHeader("Keep-Alive", "test")
         .WithBody("bbb")
         .WithDelay(12345)
         .WithTransformer()

--- a/test/WireMock.Net.Tests/WireMockAdminApiTests.IWireMockAdminApi_GetMappingsCode.verified.txt
+++ b/test/WireMock.Net.Tests/WireMockAdminApiTests.IWireMockAdminApi_GetMappingsCode.verified.txt
@@ -18,7 +18,7 @@ server
     )
     .WithGuid("1b731398-4a5b-457f-a6e3-d65e541c428f")
     .RespondWith(Response.Create()
-        .WithHeader("hk)", "hv")
+        .WithHeader("hk", "hv")
         .WithBody("2")
     );
 


### PR DESCRIPTION
This PR removes redundant ")" character from header names.