### PR TITLE
C# code generator improvements

### DIFF
--- a/src/WireMock.Net/Serialization/MappingConverter.cs
+++ b/src/WireMock.Net/Serialization/MappingConverter.cs
@@ -149,7 +149,7 @@ internal class MappingConverter
             {
                 case BodyType.String:
                 case BodyType.FormUrlEncoded:
-                    sb.AppendLine($"        .WithBody(\"{response.ResponseMessage.BodyData.BodyAsString}\")");
+                    sb.AppendLine($"        .WithBody(\"{EscapeCSharpString(bodyData.BodyAsString)}\")");
                     break;
             }
         }
@@ -445,8 +445,10 @@ internal class MappingConverter
 
     private static string ToValueArguments(string[]? values, string defaultValue = "")
     {
-        return values is { } ? string.Join(", ", values.Select(v => $"\"{v}\"")) : $"\"{defaultValue}\"";
+        return values is { } ? string.Join(", ", values.Select(v => $"\"{EscapeCSharpString(v)}\"")) : $"\"{EscapeCSharpString(defaultValue)}\"";
     }
+
+    private static string? EscapeCSharpString(string? value) => value?.Replace("\"", "\\\"");
 
     private static WebProxyModel? MapWebProxy(WebProxySettings? settings)
     {

--- a/test/WireMock.Net.Tests/WireMockAdminApiTests.IWireMockAdminApi_GetMappingsCode.verified.txt
+++ b/test/WireMock.Net.Tests/WireMockAdminApiTests.IWireMockAdminApi_GetMappingsCode.verified.txt
@@ -16,11 +16,13 @@ server
         .UsingMethod("POST")
         .WithPath("/foo2")
         .WithParam("p2", "abc")
+        .WithHeader("h1", "W/\"234f2q3r\"", true)
     )
     .WithGuid("1b731398-4a5b-457f-a6e3-d65e541c428f")
     .RespondWith(Response.Create()
         .WithStatusCode("201")
         .WithHeader("hk", "hv")
+        .WithHeader("ETag", "W/\"168d8e\"")
         .WithBody("2")
     );
 

--- a/test/WireMock.Net.Tests/WireMockAdminApiTests.IWireMockAdminApi_GetMappingsCode.verified.txt
+++ b/test/WireMock.Net.Tests/WireMockAdminApiTests.IWireMockAdminApi_GetMappingsCode.verified.txt
@@ -34,5 +34,32 @@ server
     .WithGuid("f74fd144-df53-404f-8e35-da22a640bd5f")
     .RespondWith(Response.Create()
         .WithStatusCode(208)
+        .WithBodyAsJson(new
+        {
+            a = 1,
+            b = 1.2,
+            d = true,
+            e = false,
+            f = new [] { 1, 2, 3, 4 },
+            g = new
+            {
+                z1 = 1,
+                z2 = 2,
+                z3 = new [] { "a", "b", "c" },
+                z4 = new []
+                {
+                    new
+                    {
+                        a = 1,
+                        b = 2
+                    },
+                    new
+                    {
+                        a = 2,
+                        b = 3
+                    }
+                }
+            }
+        })
     );
 

--- a/test/WireMock.Net.Tests/WireMockAdminApiTests.cs
+++ b/test/WireMock.Net.Tests/WireMockAdminApiTests.cs
@@ -740,6 +740,7 @@ public class WireMockAdminApiTests
                 Request.Create()
                     .WithPath("/foo2")
                     .WithParam("p2", "abc")
+                    .WithHeader("h1", "W/\"234f2q3r\"")
                     .UsingPost()
             )
             .WithGuid(guid2)
@@ -747,6 +748,7 @@ public class WireMockAdminApiTests
                 Response.Create()
                     .WithStatusCode("201")
                     .WithHeader("hk", "hv")
+                    .WithHeader("ETag", "W/\"168d8e\"")
                     .WithBody("2")
             );
 

--- a/test/WireMock.Net.Tests/WireMockAdminApiTests.cs
+++ b/test/WireMock.Net.Tests/WireMockAdminApiTests.cs
@@ -762,7 +762,7 @@ public class WireMockAdminApiTests
             .RespondWith(
                 Response.Create()
                     .WithStatusCode(HttpStatusCode.AlreadyReported)
-                    .WithBodyAsJson(new { x = 1 })
+                    .WithBodyAsJson(new { a = 1, b=1.2, d=true, e=false, f=new[]{1,2,3,4}, g= new{z1=1, z2=2, z3=new []{"a","b","c"}, z4=new[]{new {a=1, b=2},new {a=2, b=3}}} })
             );
 
         // Act


### PR DESCRIPTION
This PR brings the following improvements:
- Add quote escaping in generated C# strings
- Handle JSON in the response body. Json is converted to C# anonymous object definition and fed into `WithBodyAsJson` method.