### PR TITLE
JsonPartialMatcher - match guid and string

### DIFF
--- a/src/WireMock.Net/Matchers/AbstractJsonPartialMatcher.cs
+++ b/src/WireMock.Net/Matchers/AbstractJsonPartialMatcher.cs
@@ -74,6 +74,13 @@ public abstract class AbstractJsonPartialMatcher : JsonMatcher
             }
         }
 
+        if (input != null &&
+        	((value.Type == JTokenType.Guid && input.Type == JTokenType.String) ||
+        	(value.Type == JTokenType.String && input.Type == JTokenType.Guid)))
+        {
+        	return IsMatch(value.ToString(), input.ToString());
+        }
+
         if (input == null || value.Type != input.Type)
         {
             return false;

--- a/test/WireMock.Net.Tests/Matchers/JsonPartialMatcherTests.cs
+++ b/test/WireMock.Net.Tests/Matchers/JsonPartialMatcherTests.cs
@@ -282,6 +282,25 @@ public class JsonPartialMatcherTests
     }
 
     [Fact]
+    public void JsonPartialMatcher_IsMatch_GuidAsString()
+    {
+    	// Assign
+    	var guid = Guid.NewGuid();
+    	var matcher = new JsonPartialMatcher(new { Id = 1, Name = guid });
+
+    	// Act
+    	var jObject = new JObject
+    	{
+    		{ "Id", new JValue(1) },
+    		{ "Name", new JValue(guid.ToString()) }
+    	};
+    	double match = matcher.IsMatch(jObject);
+
+    	// Assert
+    	Assert.Equal(1.0, match);
+    }
+
+    [Fact]
     public void JsonPartialMatcher_IsMatch_WithIgnoreCaseTrue_JObjectAsString()
     {
         // Assign 

--- a/test/WireMock.Net.Tests/Matchers/JsonPartialMatcherTests.cs
+++ b/test/WireMock.Net.Tests/Matchers/JsonPartialMatcherTests.cs
@@ -200,6 +200,27 @@ public class JsonPartialMatcherTests
     }
 
     [Fact]
+    public void JsonPartialMatcher_IsMatch_GuidAsString_UsingRegex()
+    {
+        var guid = new Guid("1111238e-b775-44a9-a263-95e570135c94");
+        var matcher = new JsonPartialMatcher(new {
+            Id = 1,
+            Name = "^1111[a-fA-F0-9]{4}(-[a-fA-F0-9]{4}){3}-[a-fA-F0-9]{12}$"
+        }, false, false, true);
+
+        // Act
+        var jObject = new JObject
+        {
+            { "Id", new JValue(1) },
+            { "Name", new JValue(guid) }
+        };
+        double match = matcher.IsMatch(jObject);
+
+        // Assert
+        Assert.Equal(1.0, match);
+    }
+
+    [Fact]
     public void JsonPartialMatcher_IsMatch_WithIgnoreCaseTrue_JObject()
     {
         // Assign 


### PR DESCRIPTION
Closes #971 

Adds an ability for a JsonPartialMatcher to match Guid and String values when the matcher is configured using an anonymous object with Guid fields