### PR TITLE
Support for xml namespaces in XPathMatcher

### DIFF
--- a/src/WireMock.Net.Abstractions/Admin/Mappings/MatcherModel.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/MatcherModel.cs
@@ -1,3 +1,5 @@
+using System.Xml.Linq;
+
 namespace WireMock.Admin.Mappings;
 
 /// <summary>
@@ -72,5 +74,11 @@ public class MatcherModel
     /// Content Matcher
     /// </summary>
     public MatcherModel? ContentMatcher { get; set; }
+    #endregion
+
+    #region XPathMatcher
+
+    public XmlNamespace[]? XmlNamespaceMap { get; set; }
+
     #endregion
 }

--- a/src/WireMock.Net.Abstractions/Admin/Mappings/MatcherModel.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/MatcherModel.cs
@@ -1,5 +1,3 @@
-using System.Xml.Linq;
-
 namespace WireMock.Admin.Mappings;
 
 /// <summary>

--- a/src/WireMock.Net.Abstractions/Admin/Mappings/MatcherModel.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/MatcherModel.cs
@@ -77,8 +77,6 @@ public class MatcherModel
     #endregion
 
     #region XPathMatcher
-
     public XmlNamespace[]? XmlNamespaceMap { get; set; }
-
     #endregion
 }

--- a/src/WireMock.Net.Abstractions/Admin/Mappings/XmlNamespace.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/XmlNamespace.cs
@@ -1,0 +1,20 @@
+namespace WireMock.Admin.Mappings;
+
+/// <summary>
+/// Defines an xml namespace consisting of prefix and uri.
+/// <example>xmlns:i="http://www.w3.org/2001/XMLSchema-instance"</example>
+/// </summary>
+public class XmlNamespace
+{
+    /// <summary>
+    /// The prefix.
+    /// <example>i</example>
+    /// </summary>
+    public string Prefix { get; set; }
+
+    /// <summary>
+    /// The uri.
+    /// <example>http://www.w3.org/2001/XMLSchema-instance</example>
+    /// </summary>
+    public string Uri { get; set; }
+}

--- a/src/WireMock.Net.Abstractions/Admin/Mappings/XmlNamespace.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/XmlNamespace.cs
@@ -11,11 +11,11 @@ public class XmlNamespace
     /// The prefix.
     /// <example>i</example>
     /// </summary>
-    public string Prefix { get; set; }
+    public string Prefix { get; set; } = null!;
 
     /// <summary>
     /// The uri.
     /// <example>http://www.w3.org/2001/XMLSchema-instance</example>
     /// </summary>
-    public string Uri { get; set; }
+    public string Uri { get; set; } = null!;
 }

--- a/src/WireMock.Net.Abstractions/Admin/Mappings/XmlNamespace.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/XmlNamespace.cs
@@ -4,6 +4,7 @@ namespace WireMock.Admin.Mappings;
 /// Defines an xml namespace consisting of prefix and uri.
 /// <example>xmlns:i="http://www.w3.org/2001/XMLSchema-instance"</example>
 /// </summary>
+[FluentBuilder.AutoGenerateBuilder]
 public class XmlNamespace
 {
     /// <summary>

--- a/src/WireMock.Net/Matchers/XPathMatcher.cs
+++ b/src/WireMock.Net/Matchers/XPathMatcher.cs
@@ -1,5 +1,5 @@
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
 using System.Linq;
 using System.Xml;
 using System.Xml.XPath;
@@ -7,6 +7,7 @@ using AnyOfTypes;
 using WireMock.Extensions;
 using WireMock.Models;
 using Stef.Validation;
+using WireMock.Admin.Mappings;
 #if !NETSTANDARD1_3
 using Wmhelp.XPath2;
 #endif
@@ -19,16 +20,22 @@ namespace WireMock.Matchers;
 /// <seealso cref="IStringMatcher" />
 public class XPathMatcher : IStringMatcher
 {
+    private readonly List<XmlNamespace> _xmlNamespaceMap;
     private readonly AnyOf<string, StringPattern>[] _patterns;
 
     /// <inheritdoc />
     public MatchBehaviour MatchBehaviour { get; }
 
     /// <summary>
+    /// Array of namespace prefix and uri.
+    /// </summary>
+    public XmlNamespace[] XmlNamespaceMap => _xmlNamespaceMap.ToArray();
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="XPathMatcher"/> class.
     /// </summary>
     /// <param name="patterns">The patterns.</param>
-    public XPathMatcher(params AnyOf<string, StringPattern>[] patterns) : this(MatchBehaviour.AcceptOnMatch, MatchOperator.Or, patterns)
+    public XPathMatcher(params AnyOf<string, StringPattern>[] patterns) : this(MatchBehaviour.AcceptOnMatch, MatchOperator.Or, null, patterns)
     {
     }
 
@@ -37,12 +44,20 @@ public class XPathMatcher : IStringMatcher
     /// </summary>
     /// <param name="matchBehaviour">The match behaviour.</param>
     /// <param name="matchOperator">The <see cref="Matchers.MatchOperator"/> to use. (default = "Or")</param>
+    /// <param name="xmlNamespaceMap">The xml namespaces of the xml document.</param>
     /// <param name="patterns">The patterns.</param>
     public XPathMatcher(
         MatchBehaviour matchBehaviour,
         MatchOperator matchOperator = MatchOperator.Or,
+        XmlNamespace[]? xmlNamespaceMap = null,
         params AnyOf<string, StringPattern>[] patterns)
     {
+        _xmlNamespaceMap = new List<XmlNamespace>();
+        if (xmlNamespaceMap != null)
+        {
+            _xmlNamespaceMap.AddRange(xmlNamespaceMap);
+        }
+
         _patterns = Guard.NotNull(patterns);
         MatchBehaviour = matchBehaviour;
         MatchOperator = matchOperator;
@@ -52,24 +67,34 @@ public class XPathMatcher : IStringMatcher
     public MatchResult IsMatch(string? input)
     {
         var score = MatchScores.Mismatch;
-        Exception? exception = null;
 
-        if (input != null && TryGetXPathNavigator(input, out var nav))
+        if (input == null)
         {
-            try
-            {
-#if NETSTANDARD1_3
-                score = MatchScores.ToScore(_patterns.Select(p => true.Equals(nav.Evaluate($"boolean({p.GetPattern()})"))).ToArray(), MatchOperator);
-#else
-                score = MatchScores.ToScore(_patterns.Select(p => true.Equals(nav.XPath2Evaluate($"boolean({p.GetPattern()})"))).ToArray(), MatchOperator);
-#endif
-            }
-            catch (Exception ex)
-            {
-                exception = ex;
-            }
+            return CreateMatchResult(score);
         }
 
+        try
+        {
+            var xPathEvaluator = new XPathEvaluator();
+            xPathEvaluator.Load(input);
+
+            if (!xPathEvaluator.IsXmlDocumentLoaded)
+            {
+                return CreateMatchResult(score);
+            }
+        
+            score = MatchScores.ToScore(xPathEvaluator.Evaluate(_patterns, _xmlNamespaceMap), MatchOperator);
+        }
+        catch (Exception exception)
+        {
+            return CreateMatchResult(score, exception);
+        }
+
+        return CreateMatchResult(score);
+    }
+    
+    private MatchResult CreateMatchResult(double score, Exception? exception = null)
+    {
         return new MatchResult(MatchBehaviourHelper.Convert(MatchBehaviour, score), exception);
     }
 
@@ -84,18 +109,54 @@ public class XPathMatcher : IStringMatcher
 
     /// <inheritdoc />
     public string Name => nameof(XPathMatcher);
-
-    private static bool TryGetXPathNavigator(string input, [NotNullWhen(true)] out XPathNavigator? nav)
+    
+    private class XPathEvaluator
     {
-        try
+        private XmlDocument? _xmlDocument;
+        private XPathNavigator? _xpathNavigator;
+
+        public bool IsXmlDocumentLoaded => _xmlDocument != null;
+
+        public void Load(string input)
         {
-            nav = new XmlDocument { InnerXml = input }.CreateNavigator()!;
-            return true;
+            try
+            {
+                _xmlDocument = new XmlDocument { InnerXml = input };
+                _xpathNavigator = _xmlDocument.CreateNavigator();
+            }
+            catch
+            {
+                _xmlDocument = default;
+            }
         }
-        catch
+
+        public bool[] Evaluate(AnyOf<string, StringPattern>[] patterns, IEnumerable<XmlNamespace> xmlNamespaceMap)
         {
-            nav = default;
-            return false;
+            XmlNamespaceManager? xmlNamespaceManager = GetXmlNamespaceManager(xmlNamespaceMap);
+            return patterns
+                .Select(p =>
+#if NETSTANDARD1_3
+                    true.Equals(_xpathNavigator.Evaluate($"boolean({p.GetPattern()})", xmlNamespaceManager)))
+#else
+                    true.Equals(_xpathNavigator.XPath2Evaluate($"boolean({p.GetPattern()})", xmlNamespaceManager)))
+#endif
+                .ToArray();
+        }
+
+        private XmlNamespaceManager? GetXmlNamespaceManager(IEnumerable<XmlNamespace> xmlNamespaceMap)
+        {
+            if (_xpathNavigator == null)
+            {
+                return default;
+            }
+
+            var nsManager = new XmlNamespaceManager(_xpathNavigator.NameTable);
+            foreach (XmlNamespace xmlNamespace in xmlNamespaceMap)
+            {
+                nsManager.AddNamespace(xmlNamespace.Prefix, xmlNamespace.Uri);
+            }
+
+            return nsManager;
         }
     }
 }

--- a/src/WireMock.Net/Matchers/XPathMatcher.cs
+++ b/src/WireMock.Net/Matchers/XPathMatcher.cs
@@ -20,7 +20,6 @@ namespace WireMock.Matchers;
 /// <seealso cref="IStringMatcher" />
 public class XPathMatcher : IStringMatcher
 {
-    private readonly XmlNamespace[]? _xmlNamespaceMap;
     private readonly AnyOf<string, StringPattern>[] _patterns;
 
     /// <inheritdoc />
@@ -29,7 +28,7 @@ public class XPathMatcher : IStringMatcher
     /// <summary>
     /// Array of namespace prefix and uri.
     /// </summary>
-    public XmlNamespace[]? XmlNamespaceMap => _xmlNamespaceMap;
+    public XmlNamespace[]? XmlNamespaceMap { get; private set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="XPathMatcher"/> class.
@@ -52,8 +51,8 @@ public class XPathMatcher : IStringMatcher
         XmlNamespace[]? xmlNamespaceMap = null,
         params AnyOf<string, StringPattern>[] patterns)
     {
-        _xmlNamespaceMap = xmlNamespaceMap;
         _patterns = Guard.NotNull(patterns);
+        XmlNamespaceMap = xmlNamespaceMap;
         MatchBehaviour = matchBehaviour;
         MatchOperator = matchOperator;
     }
@@ -78,7 +77,7 @@ public class XPathMatcher : IStringMatcher
                 return CreateMatchResult(score);
             }
         
-            score = MatchScores.ToScore(xPathEvaluator.Evaluate(_patterns, _xmlNamespaceMap), MatchOperator);
+            score = MatchScores.ToScore(xPathEvaluator.Evaluate(_patterns, XmlNamespaceMap), MatchOperator);
         }
         catch (Exception exception)
         {

--- a/src/WireMock.Net/Matchers/XPathMatcher.cs
+++ b/src/WireMock.Net/Matchers/XPathMatcher.cs
@@ -20,7 +20,7 @@ namespace WireMock.Matchers;
 /// <seealso cref="IStringMatcher" />
 public class XPathMatcher : IStringMatcher
 {
-    private readonly List<XmlNamespace> _xmlNamespaceMap;
+    private readonly XmlNamespace[]? _xmlNamespaceMap;
     private readonly AnyOf<string, StringPattern>[] _patterns;
 
     /// <inheritdoc />
@@ -29,7 +29,7 @@ public class XPathMatcher : IStringMatcher
     /// <summary>
     /// Array of namespace prefix and uri.
     /// </summary>
-    public XmlNamespace[] XmlNamespaceMap => _xmlNamespaceMap.ToArray();
+    public XmlNamespace[]? XmlNamespaceMap => _xmlNamespaceMap;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="XPathMatcher"/> class.
@@ -52,12 +52,7 @@ public class XPathMatcher : IStringMatcher
         XmlNamespace[]? xmlNamespaceMap = null,
         params AnyOf<string, StringPattern>[] patterns)
     {
-        _xmlNamespaceMap = new List<XmlNamespace>();
-        if (xmlNamespaceMap != null)
-        {
-            _xmlNamespaceMap.AddRange(xmlNamespaceMap);
-        }
-
+        _xmlNamespaceMap = xmlNamespaceMap;
         _patterns = Guard.NotNull(patterns);
         MatchBehaviour = matchBehaviour;
         MatchOperator = matchOperator;
@@ -130,7 +125,7 @@ public class XPathMatcher : IStringMatcher
             }
         }
 
-        public bool[] Evaluate(AnyOf<string, StringPattern>[] patterns, IEnumerable<XmlNamespace> xmlNamespaceMap)
+        public bool[] Evaluate(AnyOf<string, StringPattern>[] patterns, IEnumerable<XmlNamespace>? xmlNamespaceMap)
         {
             XmlNamespaceManager? xmlNamespaceManager = GetXmlNamespaceManager(xmlNamespaceMap);
             return patterns
@@ -143,9 +138,9 @@ public class XPathMatcher : IStringMatcher
                 .ToArray();
         }
 
-        private XmlNamespaceManager? GetXmlNamespaceManager(IEnumerable<XmlNamespace> xmlNamespaceMap)
+        private XmlNamespaceManager? GetXmlNamespaceManager(IEnumerable<XmlNamespace>? xmlNamespaceMap)
         {
-            if (_xpathNavigator == null)
+            if (_xpathNavigator == null || xmlNamespaceMap == null)
             {
                 return default;
             }

--- a/src/WireMock.Net/Serialization/MatcherMapper.cs
+++ b/src/WireMock.Net/Serialization/MatcherMapper.cs
@@ -160,6 +160,10 @@ internal class MatcherMapper
             case JsonPartialWildcardMatcher jsonPartialWildcardMatcher:
                 model.Regex = jsonPartialWildcardMatcher.Regex;
                 break;
+
+            case XPathMatcher xpathMatcher:
+                model.XmlNamespaceMap = xpathMatcher.XmlNamespaceMap;
+                break;
         }
 
         switch (matcher)

--- a/src/WireMock.Net/Serialization/MatcherMapper.cs
+++ b/src/WireMock.Net/Serialization/MatcherMapper.cs
@@ -101,7 +101,8 @@ internal class MatcherMapper
                 return new JmesPathMatcher(matchBehaviour, matchOperator, stringPatterns);
 
             case nameof(XPathMatcher):
-                return new XPathMatcher(matchBehaviour, matchOperator, stringPatterns);
+                var xmlNamespaces = matcher.XmlNamespaceMap;
+                return new XPathMatcher(matchBehaviour, matchOperator, xmlNamespaces, stringPatterns);
 
             case nameof(WildcardMatcher):
                 return new WildcardMatcher(matchBehaviour, stringPatterns, ignoreCase, matchOperator);

--- a/test/WireMock.Net.Tests/Serialization/MatcherMapperTests.cs
+++ b/test/WireMock.Net.Tests/Serialization/MatcherMapperTests.cs
@@ -583,7 +583,6 @@ public class MatcherMapperTests
 
         // Assert
         matcher.MatchBehaviour.Should().Be(MatchBehaviour.AcceptOnMatch);
-        matcher.XmlNamespaceMap.Should().NotBeNull();
-        matcher.XmlNamespaceMap.Should().HaveCount(0);
+        matcher.XmlNamespaceMap.Should().BeNull();
     }
 }

--- a/test/WireMock.Net.Tests/Serialization/MatcherMapperTests.cs
+++ b/test/WireMock.Net.Tests/Serialization/MatcherMapperTests.cs
@@ -522,4 +522,48 @@ public class MatcherMapperTests
         matcher.ContentTypeMatcher.Should().BeAssignableTo<ContentTypeMatcher>().Which.GetPatterns().Should().ContainSingle("text/json");
     }
 #endif
+
+    [Fact]
+    public void MatcherMapper_Map_MatcherModel_XPathMatcher_WithXmlNamespaces_As_String()
+    {
+        // Assign
+        var pattern = "/s:Envelope/s:Body/*[local-name()='QueryRequest']";
+        var model = new MatcherModel
+        {
+            Name = "XPathMatcher",
+            Pattern = pattern,
+            XmlNamespaceMap = new[]
+            {
+                new XmlNamespace { Prefix = "s", Uri = "http://schemas.xmlsoap.org/soap/envelope/" }
+            }
+        };
+
+        // Act
+        var matcher = (XPathMatcher)_sut.Map(model)!;
+
+        // Assert
+        matcher.MatchBehaviour.Should().Be(MatchBehaviour.AcceptOnMatch);
+        matcher.XmlNamespaceMap.Should().NotBeNull();
+        matcher.XmlNamespaceMap.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void MatcherMapper_Map_MatcherModel_XPathMatcher_WithoutXmlNamespaces_As_String()
+    {
+        // Assign
+        var pattern = "/s:Envelope/s:Body/*[local-name()='QueryRequest']";
+        var model = new MatcherModel
+        {
+            Name = "XPathMatcher",
+            Pattern = pattern
+        };
+
+        // Act
+        var matcher = (XPathMatcher)_sut.Map(model)!;
+
+        // Assert
+        matcher.MatchBehaviour.Should().Be(MatchBehaviour.AcceptOnMatch);
+        matcher.XmlNamespaceMap.Should().NotBeNull();
+        matcher.XmlNamespaceMap.Should().HaveCount(0);
+    }
 }

--- a/test/WireMock.Net.Tests/Serialization/MatcherMapperTests.cs
+++ b/test/WireMock.Net.Tests/Serialization/MatcherMapperTests.cs
@@ -146,6 +146,26 @@ public class MatcherMapperTests
     }
 
     [Fact]
+    public void MatcherMapper_Map_XPathMatcher()
+    {
+        // Assign
+        var xmlNamespaceMap = new[]
+        {
+            new XmlNamespace { Prefix = "s", Uri = "http://schemas.xmlsoap.org/soap/envelope/" },
+            new XmlNamespace { Prefix = "i", Uri = "http://www.w3.org/2001/XMLSchema-instance" },
+            new XmlNamespace { Prefix = "q", Uri = "urn://MyWcfService" }
+        };
+        var matcher = new XPathMatcher(MatchBehaviour.AcceptOnMatch, MatchOperator.And, xmlNamespaceMap);
+
+        // Act
+        var model = _sut.Map(matcher)!;
+
+        // Assert
+        model.XmlNamespaceMap.Should().NotBeNull();
+        model.XmlNamespaceMap.Should().BeEquivalentTo(xmlNamespaceMap);
+    }
+
+    [Fact]
     public void MatcherMapper_Map_MatcherModel_Null()
     {
         // Act


### PR DESCRIPTION
We have round about 4800 WCF Services in our landscape, thus this faker is really helpful. In order to write more easy request body matchers I would like to write more easy xpath expressions using the xpath matcher as follows:

``` json
{
    "Title": "wcf test",
    "Request": {
        "Path": {
            "Matchers": [
                {
                    "Name": "WildcardMatcher",
                    "Pattern": "/MyService.svc"
                }
            ]
        },
        "Methods": [
            "post"
        ],
                "Headers": [
                    {
                        "Name": "Content-Type",
                        "Matchers": [
                            {
                                "Name": "WildcardMatcher",
                                "Pattern": "text/xml; charset=utf-8",
                                "IgnoreCase": true
                            }
                        ],
                        "IgnoreCase": true
                    },
                    {
                        "Name": "SOAPAction",
                        "Matchers": [
                            {
                                "Name": "WildcardMatcher",
                                "Pattern": "*urn://MyService/Query*",
                                "IgnoreCase": true
                            }
                        ],
                        "IgnoreCase": true
                    }
                ],
        "Body": {
            "Matcher": {
                "Name": "XPathMatcher",
                "Pattern": "/s:Envelope/s:Body/q:QueryRequest",
                "XmlNamespaceMap": [
                    { 
                        "Prefix": "s",
                        "Uri": "http://schemas.xmlsoap.org/soap/envelope/"
                    },
                    { 
                        "Prefix": "i",
                        "Uri": "http://www.w3.org/2001/XMLSchema-instance"
                    },
                    { 
                        "Prefix": "q",
                        "Uri": "urn://Schleupen.AS.MT.BIB.Buecher.BuchQueryService_3.1"
                    }
                ]
            }
        }
    },
    "Response": {
        "StatusCode": 200,
        "Body": "<s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\"><s:Body><QueryResponse xmlns=\"urn://MyService\"></QueryResponse></s:Body></s:Envelope>",
        "Headers": {
            "Content-Type": "text/xml"
        }
    }
}
```
This implementation handles this so that 

``` xml
<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Header></s:Header><s:Body><QueryRequest xmlns="urn://MyService"><MaxResults i:nil="true" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"/><Restriction i:nil="true" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"/><SearchMode i:nil="true" xmlns:i="http://www.w3.org/2001/XMLSchema-instance"/></QueryRequest></s:Body></s:Envelope> 
```
matches for example.

Yes, I can use 'local-name()' etc. but I think this way it is more easy.