### PR TITLE
Use try..catch to set encoding in WireMockConsoleLogger

### DIFF
--- a/src/WireMock.Net/Logging/WireMockConsoleLogger.cs
+++ b/src/WireMock.Net/Logging/WireMockConsoleLogger.cs
@@ -15,7 +15,11 @@ public class WireMockConsoleLogger : IWireMockLogger
     /// </summary>
     public WireMockConsoleLogger()
     {
-        Console.OutputEncoding = System.Text.Encoding.UTF8;
+        try
+        {
+            Console.OutputEncoding = System.Text.Encoding.UTF8;
+        }
+        catch { }
     }
 
     /// <see cref="IWireMockLogger.Debug"/>


### PR DESCRIPTION
In Linqpad, the "console" is [just a facade](https://forum.linqpad.net/discussion/451/some-of-console-properties-are-not-working) over web browser output, so calling `Console.OutputEncoding = System.Text.Encoding.UTF8` in the constructor for `WireMockConsoleLogger` throws an exception.

This PR adds a `try..catch` block to that code, so that the logger can be used in Linqpad (and any other non-standard consoles).