### PR TITLE
Made changes to accommodate breaking change in testcontainers-dotnet 3.9

### DIFF
--- a/src/WireMock.Net.Testcontainers/WireMock.Net.Testcontainers.csproj
+++ b/src/WireMock.Net.Testcontainers/WireMock.Net.Testcontainers.csproj
@@ -29,7 +29,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Stef.Validation" Version="0.1.1" />
-        <PackageReference Include="Testcontainers" Version="[3.7.0]" />
+        <PackageReference Include="Testcontainers" Version="[3.9.0]" />
         <PackageReference Include="JetBrains.Annotations" VersionOverride="2022.3.1" PrivateAssets="All" Version="2023.3.0" />
     </ItemGroup>
 

--- a/src/WireMock.Net.Testcontainers/WireMockContainer.cs
+++ b/src/WireMock.Net.Testcontainers/WireMockContainer.cs
@@ -4,7 +4,6 @@ using System.Net.Http.Headers;
 using System.Text;
 using DotNet.Testcontainers.Containers;
 using JetBrains.Annotations;
-using Microsoft.Extensions.Logging;
 using RestEase;
 using Stef.Validation;
 using WireMock.Client;
@@ -26,8 +25,7 @@ public sealed class WireMockContainer : DockerContainer
     /// Initializes a new instance of the <see cref="WireMockContainer" /> class.
     /// </summary>
     /// <param name="configuration">The container configuration.</param>
-    /// <param name="logger">The logger.</param>
-    public WireMockContainer(WireMockConfiguration configuration, ILogger logger) : base(configuration, logger)
+    public WireMockContainer(WireMockConfiguration configuration) : base(configuration)
     {
         _configuration = Guard.NotNull(configuration);
     }

--- a/src/WireMock.Net.Testcontainers/WireMockContainerBuilder.cs
+++ b/src/WireMock.Net.Testcontainers/WireMockContainerBuilder.cs
@@ -138,7 +138,7 @@ public sealed class WireMockContainerBuilder : ContainerBuilder<WireMockContaine
     {
         Validate();
 
-        return new WireMockContainer(DockerResourceConfiguration, TestcontainersSettings.Logger);
+        return new WireMockContainer(DockerResourceConfiguration);
     }
 
     /// <inheritdoc />


### PR DESCRIPTION
Made changes to accommodate breaking change in testcontainers-dotnet 3.9

[3.9.0](https://github.com/testcontainers/testcontainers-dotnet/releases/tag/3.9.0)
[1146](https://github.com/testcontainers/testcontainers-dotnet/pull/1146)
[1100](https://github.com/testcontainers/testcontainers-dotnet/pull/1100)
