### PR TITLE
Fix listen on AnyIP for url 0.0.0.0

### DIFF
--- a/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard.cs
+++ b/src/WireMock.Net/Owin/AspNetCoreSelfHost.NETStandard.cs
@@ -75,8 +75,15 @@ namespace WireMock.Owin
 
         private static void Listen(KestrelServerOptions kestrelOptions, HostUrlDetails urlDetail, Action<ListenOptions> configure)
         {
+            // Listens on any IP with the given port.
+            if (urlDetail is { Port: > 0, Host: "0.0.0.0" })
+            {
+                kestrelOptions.ListenAnyIP(urlDetail.Port, configure);
+                return;
+            }
+            
             // Listens on ::1 and 127.0.0.1 with the given port.
-            if (urlDetail is { Port: > 0, Host: "localhost" or "127.0.0.1" or "0.0.0.0" or "::1" })
+            if (urlDetail is { Port: > 0, Host: "localhost" or "127.0.0.1" or "::1" })
             {
                 kestrelOptions.ListenLocalhost(urlDetail.Port, configure);
                 return;

--- a/test/WireMock.Net.Tests/Facts/IgnoreOnContinuousIntegrationFact.cs
+++ b/test/WireMock.Net.Tests/Facts/IgnoreOnContinuousIntegrationFact.cs
@@ -1,19 +1,22 @@
 // Copyright © WireMock.Net
+
 using System;
 using Xunit;
 
-namespace WireMock.Net.Tests.Facts
-{
-    public sealed class IgnoreOnContinuousIntegrationFact : FactAttribute
-    {
-        public IgnoreOnContinuousIntegrationFact()
-        {
-            if (IsContinuousIntegration())
-            {
-                Skip = "Ignore when run via CI/CD";
-            }
-        }
+namespace WireMock.Net.Tests.Facts;
 
-        private static bool IsContinuousIntegration() => Environment.GetEnvironmentVariable("TF_BUILD") != null && Environment.GetEnvironmentVariable("TF_BUILD").ToLower() == "true";
+public sealed class IgnoreOnContinuousIntegrationFact : FactAttribute
+{
+    private static readonly string _skipReason = "Ignore when run via CI/CD";
+    private static readonly bool _isContinuousIntegrationAzure = bool.TryParse(Environment.GetEnvironmentVariable("TF_BUILD"), out var isTF) && isTF;
+    private static readonly bool _isContinuousIntegrationGithub = bool.TryParse(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"), out var isGH) && isGH;
+    private static bool IsContinuousIntegration() => _isContinuousIntegrationAzure || _isContinuousIntegrationGithub;
+    
+    public IgnoreOnContinuousIntegrationFact()
+    {
+        if (IsContinuousIntegration())
+        {
+            Skip = _skipReason;
+        }
     }
 }

--- a/test/WireMock.Net.Tests/Facts/IgnoreOnContinuousIntegrationFact.cs
+++ b/test/WireMock.Net.Tests/Facts/IgnoreOnContinuousIntegrationFact.cs
@@ -1,0 +1,19 @@
+// Copyright © WireMock.Net
+using System;
+using Xunit;
+
+namespace WireMock.Net.Tests.Facts
+{
+    public sealed class IgnoreOnContinuousIntegrationFact : FactAttribute
+    {
+        public IgnoreOnContinuousIntegrationFact()
+        {
+            if (IsContinuousIntegration())
+            {
+                Skip = "Ignore when run via CI/CD";
+            }
+        }
+
+        private static bool IsContinuousIntegration() => Environment.GetEnvironmentVariable("TF_BUILD") != null && Environment.GetEnvironmentVariable("TF_BUILD").ToLower() == "true";
+    }
+}

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -244,7 +244,7 @@ public partial class WireMockServerTests
         foreach (var addr in IPv6)
         {
             // Act
-            var response = await new HttpClient().GetStringAsync("http://" + addr + ":" server.Ports[0] + "/foo").ConfigureAwait(false);
+            var response = await new HttpClient().GetStringAsync("http://" + addr + ":" + server.Ports[0] + "/foo").ConfigureAwait(false);
     
             // Asser.
             response.Should().Be("x");

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -235,7 +235,7 @@ public partial class WireMockServerTests
         foreach (var addr in IPv4)
         {
             // Act
-            var response = await new HttpClient().GetStringAsync($"http://{addr}:" + server.Ports[0] + "/foo").ConfigureAwait(false);
+            var response = await new HttpClient().GetStringAsync("http://" + addr + ":" + server.Ports[0] + "/foo").ConfigureAwait(false);
     
             // Asser.
             response.Should().Be("x");
@@ -244,7 +244,7 @@ public partial class WireMockServerTests
         foreach (var addr in IPv6)
         {
             // Act
-            var response = await new HttpClient().GetStringAsync($"http://{addr}:" + server.Ports[0] + "/foo").ConfigureAwait(false);
+            var response = await new HttpClient().GetStringAsync("http://" + addr + ":" server.Ports[0] + "/foo").ConfigureAwait(false);
     
             // Asser.
             response.Should().Be("x");

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -197,6 +197,7 @@ public partial class WireMockServerTests
     }
 #endif
 
+#if NET6_0_OR_GREATER
     [Fact]
     public async Task WireMockServer_WithUrl0000_Should_Listen_On_All_IPs()
     {
@@ -251,7 +252,7 @@ public partial class WireMockServerTests
     
         server.Stop();
     }
-
+#endif
     
     [Fact]
     public async Task WireMockServer_Should_respond_a_redirect_without_body()

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -9,6 +9,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.NetworkInformation;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
 using FluentAssertions;

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -203,6 +203,7 @@ public partial class WireMockServerTests
     public async Task WireMockServer_WithUrl0000_Should_Listen_On_All_IPs_IPv4()
     {
         // Arrange
+        var port = PortUtils.FindFreeTcpPort();
         var IPv4 = new List<string>();
 
         foreach (var netInterface in NetworkInterface.GetAllNetworkInterfaces())
@@ -222,7 +223,7 @@ public partial class WireMockServerTests
 
         var settings = new WireMockServerSettings
         {
-            Urls = new string[] { "http://0.0.0.0:80" },
+            Urls = new string[] { "http://0.0.0.0:" + port },
         };
         var server = WireMockServer.Start(settings);
     
@@ -246,6 +247,7 @@ public partial class WireMockServerTests
     public async Task WireMockServer_WithUrl0000_Should_Listen_On_All_IPs_IPv6()
     {
         // Arrange
+        var port = PortUtils.FindFreeTcpPort();
         var IPv6 = new List<string>();
     
         foreach (var netInterface in NetworkInterface.GetAllNetworkInterfaces())
@@ -265,7 +267,7 @@ public partial class WireMockServerTests
 
         var settings = new WireMockServerSettings
         {
-            Urls = new string[] { "http://0.0.0.0:80" },
+            Urls = new string[] { "http://0.0.0.0:" + port },
         };
         var server = WireMockServer.Start(settings);
     

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -222,11 +222,7 @@ public partial class WireMockServerTests
                 }
             }
         }
-    
-        // Asser.
-        IPv4.Should().NotBeEmpty();
-        IPv6.Should().NotBeEmpty();
-    
+
         var settings = new WireMockServerSettings
         {
             Urls = new string[] { "http://0.0.0.0:80" },

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -40,16 +40,6 @@ public partial class WireMockServerTests
     {
         _testOutputHelper = testOutputHelper;
     }
-
-    private static string[] GetIPAddressesByFamily(AddressFamily addressFamily)
-    {
-        return NetworkInterface.GetAllNetworkInterfaces()
-            .Where(ni => ni.OperationalStatus == OperationalStatus.Up)
-            .SelectMany(ni => ni.GetIPProperties().UnicastAddresses)
-            .Where(addr => addr.Address.AddressFamily == addressFamily)
-            .Select(addr => addr.Address.ToString())
-            .ToArray();
-    }
     
     [Fact]
     public void WireMockServer_Start()
@@ -210,6 +200,16 @@ public partial class WireMockServerTests
 #endif
 
 #if NET6_0_OR_GREATER
+    private static string[] GetIPAddressesByFamily(AddressFamily addressFamily)
+    {
+        return NetworkInterface.GetAllNetworkInterfaces()
+            .Where(ni => ni.OperationalStatus == OperationalStatus.Up)
+            .SelectMany(ni => ni.GetIPProperties().UnicastAddresses)
+            .Where(addr => addr.Address.AddressFamily == addressFamily)
+            .Select(addr => addr.Address.ToString())
+            .ToArray();
+    }
+    
     [IgnoreOnContinuousIntegrationFact]
     public async Task WireMockServer_WithUrl0000_Should_Listen_On_All_IPs_IPv4()
     {
@@ -235,9 +235,7 @@ public partial class WireMockServerTests
 
         server.Stop();
     }
-#endif
 
-#if NET6_0_OR_GREATER
     [IgnoreOnContinuousIntegrationFact]
     public async Task WireMockServer_WithUrl0000_Should_Listen_On_All_IPs_IPv6()
     {

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -237,7 +237,7 @@ public partial class WireMockServerTests
             // Act
             var response = await new HttpClient().GetStringAsync("http://" + addr + ":" + server.Ports[0] + "/foo").ConfigureAwait(false);
     
-            // Asser.
+            // Assert
             response.Should().Be("x");
         } 
     
@@ -246,7 +246,7 @@ public partial class WireMockServerTests
             // Act
             var response = await new HttpClient().GetStringAsync("http://" + addr + ":" + server.Ports[0] + "/foo").ConfigureAwait(false);
     
-            // Asser.
+            // Assert
             response.Should().Be("x");
         }
     
@@ -306,7 +306,7 @@ public partial class WireMockServerTests
         // Act
         var response = await new HttpClient().GetStringAsync("http://localhost:" + server.Ports[0] + "/foo").ConfigureAwait(false);
 
-        // Asser.
+        // Assert
         response.Should().Be("x");
 
         server.Stop();
@@ -332,7 +332,7 @@ public partial class WireMockServerTests
         await new HttpClient().GetStringAsync("http://localhost:" + server.Ports[0] + "/foo").ConfigureAwait(false);
         watch.Stop();
 
-        // Asser.
+        // Assert
         watch.ElapsedMilliseconds.Should().BeGreaterOrEqualTo(0);
 
         server.Stop();

--- a/test/WireMock.Net.Tests/WireMockServerTests.cs
+++ b/test/WireMock.Net.Tests/WireMockServerTests.cs
@@ -17,6 +17,7 @@ using NFluent;
 using WireMock.Admin.Mappings;
 using WireMock.Http;
 using WireMock.Matchers;
+using WireMock.Net.Tests.Facts;
 using WireMock.Net.Tests.Serialization;
 using WireMock.Net.Xunit;
 using WireMock.RequestBuilders;
@@ -198,7 +199,7 @@ public partial class WireMockServerTests
 #endif
 
 #if NET6_0_OR_GREATER
-    [Fact]
+    [IgnoreOnContinuousIntegrationFact]
     public async Task WireMockServer_WithUrl0000_Should_Listen_On_All_IPs_IPv4()
     {
         // Arrange
@@ -241,7 +242,7 @@ public partial class WireMockServerTests
 #endif
 
 #if NET6_0_OR_GREATER
-    [Fact]
+    [IgnoreOnContinuousIntegrationFact]
     public async Task WireMockServer_WithUrl0000_Should_Listen_On_All_IPs_IPv6()
     {
         // Arrange


### PR DESCRIPTION
To listen on all available IPs this fix allows to use the following URL:

```
var settings = new WireMockServerSettings
{
    Urls = new string[] { "http://0.0.0.0:80" },
};
var server = WireMockServer.Start(settings);
```

I tried to add a test, but I think the test can be improved.
Could be split in a test for IPv4 and IPv6 and maybe the naming is not perfect.
Getting all IPs could be moved into a utility method ...
Feel free to improve afterwards.

