### PR TITLE
Allow adding digital signatures to webhook headers

### DIFF
--- a/src/WireMock.Net.Abstractions/Models/IDigitalSignature.cs
+++ b/src/WireMock.Net.Abstractions/Models/IDigitalSignature.cs
@@ -1,0 +1,41 @@
+// Copyright © WireMock.Net
+
+using System.Threading.Tasks;
+using WireMock.Util;
+
+namespace WireMock.Models;
+
+/// <summary>
+/// A delegate encapsulating logic for fetching or generating a private key.
+/// </summary>
+/// <returns>An async task containing the value of the private key.</returns>
+public delegate Task<string> PrivateKeyCallback();
+
+/// <summary>
+/// A delegate encapsulating logic for fetching or generating a digital signature.
+/// </summary>
+/// <param name="privateKey">The value of the private key returned by <see cref="PrivateKeyCallback"/>.</param>
+/// <param name="bodyData">The body data associated with the request.</param>
+/// <returns>An async task containing the value of the digital signature.</returns>
+public delegate Task<string> DigitalSignatureCallback(string privateKey, IBodyData? bodyData);
+
+/// <summary>
+/// An interface encapsulating logic for generating a digital signature.
+/// </summary>
+public interface IDigitalSignature
+{
+    /// <summary>
+    /// The header name to use for the digital signature.
+    /// </summary>
+    string HeaderName { get; set; }
+
+    /// <summary>
+    /// The callback used to fetch or generate the private key.
+    /// </summary>
+    PrivateKeyCallback PrivateKeyCallback { get; set; }
+
+    /// <summary>
+    /// The callback used to fetch or generate the digital signature.
+    /// </summary>
+    DigitalSignatureCallback DigitalSignatureCallback { get; set; }
+}

--- a/src/WireMock.Net.Abstractions/Models/IWebhookRequest.cs
+++ b/src/WireMock.Net.Abstractions/Models/IWebhookRequest.cs
@@ -60,4 +60,14 @@ public interface IWebhookRequest
     /// Gets or sets the maximum random delay in milliseconds.
     /// </summary>
     int? MaximumRandomDelay { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value used to determine if digital signatures are generated.
+    /// </summary>
+    bool? UseDigitalSignatures { get; set; }
+
+    /// <summary>
+    /// Gets or sets the values used generate digital signatures.
+    /// </summary>
+    IDigitalSignature[]? DigitalSignatures { get; set; }
 }

--- a/src/WireMock.Net/Models/DigitalSignature.cs
+++ b/src/WireMock.Net/Models/DigitalSignature.cs
@@ -1,0 +1,20 @@
+// Copyright © WireMock.Net
+
+using System.Threading.Tasks;
+
+namespace WireMock.Models;
+
+/// <summary>
+/// A class encapsulating logic for generating a digital signature.
+/// </summary>
+public class DigitalSignature : IDigitalSignature
+{
+    /// <inheritdoc/>
+    public string HeaderName { get; set; } = "";
+
+    /// <inheritdoc/>
+    public PrivateKeyCallback PrivateKeyCallback { get; set; } = async () => await Task.FromResult("");
+
+    /// <inheritdoc/>
+    public DigitalSignatureCallback DigitalSignatureCallback { get; set; } = async (privateKey, bodyData) => await Task.FromResult("");
+}

--- a/src/WireMock.Net/Models/WebhookRequest.cs
+++ b/src/WireMock.Net/Models/WebhookRequest.cs
@@ -40,4 +40,10 @@ public class WebhookRequest : IWebhookRequest
 
     /// <inheritdoc />
     public int? MaximumRandomDelay { get; set; }
+
+    /// <inheritdoc />
+    public bool? UseDigitalSignatures { get; set; }
+
+    /// <inheritdoc />
+    public IDigitalSignature[]? DigitalSignatures { get; set; }
 }


### PR DESCRIPTION
Because webhook bodies and headers are transformed separately, Handlebars cannot be used to generate digital signatures using both the body and the header. This change allows the user to specify two callbacks to use to generate a digital signature for the webhook before it is sent.