### PR TITLE
Add exception message to logging when mapping fails due to an exception.

### DIFF
--- a/examples/WireMock.Net.WebApplication.NET6/WireMockService.cs
+++ b/examples/WireMock.Net.WebApplication.NET6/WireMockService.cs
@@ -52,9 +52,9 @@ public class WireMockService : IWireMockService
             _logger.LogDebug("Admin[{0}] {1}", isAdminrequest, message);
         }
 
-        public void Error(string formatString, Exception exception)
+        public void Error(string message, Exception exception)
         {
-            _logger.LogError(formatString, exception.Message);
+            _logger.LogError(exception, message);
         }
     }
 

--- a/src/WireMock.Net.TUnit/TUnitWireMockLogger.cs
+++ b/src/WireMock.Net.TUnit/TUnitWireMockLogger.cs
@@ -51,9 +51,9 @@ public sealed class TUnitWireMockLogger : IWireMockLogger
     }
 
     /// <inheritdoc />
-    public void Error(string formatString, Exception exception)
+    public void Error(string message, Exception exception)
     {
-        _tUnitLogger.LogError(Format("Error", formatString, exception.Message), exception);
+        _tUnitLogger.LogError(Format("Error", $"{message} {{0}}", exception));
 
         if (exception is AggregateException ae)
         {

--- a/src/WireMock.Net.xUnit/TestOutputHelperWireMockLogger.cs
+++ b/src/WireMock.Net.xUnit/TestOutputHelperWireMockLogger.cs
@@ -50,15 +50,15 @@ public sealed class TestOutputHelperWireMockLogger : IWireMockLogger
     }
 
     /// <inheritdoc />
-    public void Error(string formatString, Exception exception)
+    public void Error(string message, Exception exception)
     {
-        _testOutputHelper.WriteLine(Format("Error", formatString, exception.Message));
+        _testOutputHelper.WriteLine(Format("Error", $"{message} {{0}}", exception));
 
         if (exception is AggregateException ae)
         {
             ae.Handle(ex =>
             {
-                _testOutputHelper.WriteLine(Format("Error", "Exception {0}", ex.Message));
+                _testOutputHelper.WriteLine(Format("Error", "Exception {0}", ex));
                 return true;
             });
         }

--- a/src/WireMock.Net/Owin/WireMockMiddleware.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddleware.cs
@@ -224,7 +224,7 @@ namespace WireMock.Owin
                 }
                 catch (Exception ex)
                 {
-                    _options.Logger.Error("HttpStatusCode set to 404 : No matching mapping found", ex);
+                    _options.Logger.Error("HttpStatusCode set to 404 : 'No matching mapping found', due to exception '{0}'", ex);
 
                     var notFoundResponse = ResponseMessageBuilder.Create(HttpStatusCode.NotFound, WireMockConstants.NoMatchingFound);
                     await _responseMapper.MapAsync(notFoundResponse, ctx.Response).ConfigureAwait(false);

--- a/src/WireMock.Net/Owin/WireMockMiddleware.cs
+++ b/src/WireMock.Net/Owin/WireMockMiddleware.cs
@@ -224,7 +224,7 @@ namespace WireMock.Owin
                 }
                 catch (Exception ex)
                 {
-                    _options.Logger.Error("HttpStatusCode set to 404 : 'No matching mapping found', due to exception '{0}'", ex);
+                    _options.Logger.Error("HttpStatusCode set to 404 : No matching mapping found", ex);
 
                     var notFoundResponse = ResponseMessageBuilder.Create(HttpStatusCode.NotFound, WireMockConstants.NoMatchingFound);
                     await _responseMapper.MapAsync(notFoundResponse, ctx.Response).ConfigureAwait(false);


### PR DESCRIPTION
I spent way too much time in the debugger trying to figure out why the mapping was not found. 
It was found, but an exception occurred during the mapping, leading to a misleading message.

As an aside, the exception occurred because I called `.WithMapping()` before I called `.AddProtoDefinition()`...