### PR TITLE
Add an launch inspector command to Aspire Dashboard

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -14,19 +14,10 @@ jobs:
       echo "BuildId = $(buildId)"
     displayName: 'Print buildId'
 
-  - task: CmdLine@2
-    displayName: 'Install .NET Aspire workload'
-    inputs:
-      script: 'dotnet workload install aspire'
-
   - script: |
       dotnet tool install --global dotnet-sonarscanner
       dotnet tool install --global dotnet-coverage
     displayName: 'Install dotnet tools'
-
-  - script: |
-      dotnet workload install aspire
-    displayName: 'Install aspire'
 
   - task: PowerShell@2
     displayName: "Use JDK17 by default"
@@ -39,13 +30,13 @@ jobs:
   - script: |
       dotnet dev-certs https --trust || true
     displayName: 'dotnet dev-certs https'
-  
+
   # See: https://docs.sonarsource.com/sonarcloud/enriching/test-coverage/dotnet-test-coverage
   - script: |
       dotnet sonarscanner begin /k:"WireMock-Net_WireMock.Net" /o:"wiremock-net" /d:sonar.branch.name=$(Build.SourceBranchName) /d:sonar.host.url="https://sonarcloud.io" /d:sonar.token="$(SONAR_TOKEN)" /d:sonar.pullrequest.provider=github /d:sonar.cs.vscoveragexml.reportsPaths=**/wiremock-coverage-*.xml /d:sonar.verbose=true
     displayName: 'Begin analysis on SonarCloud'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')) # Do not run for PullRequests
-  
+
   - task: DotNetCoreCLI@2
     displayName: 'Build Unit tests'
     inputs:
@@ -86,21 +77,21 @@ jobs:
       dotnet sonarscanner end /d:sonar.token="$(SONAR_TOKEN)"
     displayName: 'End analysis on SonarCloud'
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')) # Do not run for PullRequests
-  
+
   - task: whitesource.ws-bolt.bolt.wss.WhiteSource Bolt@19
     displayName: 'WhiteSource Bolt'
     condition: and(succeeded(), eq(variables['RUN_WHITESOURCE'], 'yes'))
- 
+
   - script: |
       bash <(curl https://codecov.io/bash) -t $(CODECOV_TOKEN) -f ./test/wiremock-coverage.xml
     displayName: 'Upload coverage results to codecov'
-  
+
   - task: PublishTestResults@2
     condition: and(succeeded(), eq(variables['PUBLISH_TESTRESULTS'], 'yes'))
     inputs:
       testRunner: VSTest
       testResultsFiles: '**/*.trx'
-  
+
   - task: PublishBuildArtifacts@1
     displayName: Publish coverage files
     inputs:
@@ -138,7 +129,7 @@ jobs:
       command: 'test'
       projects: './test/WireMock.Net.Middleware.Tests/WireMock.Net.Middleware.Tests.csproj'
       arguments: '--configuration Debug --framework net8.0 --collect:"XPlat Code Coverage" --logger trx'
-  
+
 - job: Windows_Release_to_MyGet
   dependsOn: Windows_Build_Test
 
@@ -169,13 +160,13 @@ jobs:
       nobuild: true
       packDirectory: '$(Build.ArtifactStagingDirectory)/packages'
       verbosityPack: 'normal'
-  
+
   - task: PublishBuildArtifacts@1
     displayName: Publish Artifacts
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')) # Do not run for PullRequests
     inputs:
       PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-  
+
   - task: DotNetCoreCLI@2
     displayName: Push to MyGet
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest')) # Do not run for PullRequests

--- a/examples-Aspire/AspireApp1.AppHost/AspireApp1.AppHost.csproj
+++ b/examples-Aspire/AspireApp1.AppHost/AspireApp1.AppHost.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsAspireHost>true</IsAspireHost>
     </PropertyGroup>
 
     <ItemGroup>
@@ -17,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
     </ItemGroup>
 
 </Project>

--- a/examples-Aspire/AspireApp1.AppHostOriginal/AspireApp1.AppHostOriginal.csproj
+++ b/examples-Aspire/AspireApp1.AppHostOriginal/AspireApp1.AppHostOriginal.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsAspireHost>true</IsAspireHost>
     </PropertyGroup>
 
     <ItemGroup>
@@ -14,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
     </ItemGroup>
 
 </Project>

--- a/src/WireMock.Net.Aspire/WireMock.Net.Aspire.csproj
+++ b/src/WireMock.Net.Aspire/WireMock.Net.Aspire.csproj
@@ -39,7 +39,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting" Version="8.2.2" />
+        <PackageReference Include="Aspire.Hosting" Version="9.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WireMock.Net.Aspire/WireMockInspector.cs
+++ b/src/WireMock.Net.Aspire/WireMockInspector.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Aspire.Hosting.WireMock;
+
+internal static class WireMockInspector
+{
+    /// <summary>
+    /// Opens the WireMockInspector tool to inspect the WireMock server.
+    /// </summary>
+    /// <param name="wireMockUrl"></param>
+    /// <param name="title"></param>
+    /// <exception cref="InvalidOperationException"></exception>
+    /// <remarks>
+    /// Copy of <see href="https://github.com/WireMock-Net/WireMockInspector/blob/main/src/WireMock.Net.Extensions.WireMockInspector/WireMockServerExtensions.cs" />
+    /// without requestFilters and no call to WaitForExit() method in the process so it doesn't block the caller.
+    /// </remarks>
+    public static void Inspect(string wireMockUrl, [CallerMemberName] string title = "")
+    {
+        try
+        {
+            var arguments = $"attach --adminUrl {wireMockUrl} --autoLoad --instanceName \"{title}\"";
+
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "wiremockinspector",
+                Arguments = arguments,
+                UseShellExecute = false
+            });
+        }
+        catch (Exception e)
+        {
+            throw new InvalidOperationException
+            (
+                message: @"Cannot find installation of WireMockInspector.
+Execute the following command to install WireMockInspector dotnet tool:
+> dotnet tool install WireMockInspector --global --no-cache --ignore-failed-sources
+To get more info please visit https://github.com/WireMock-Net/WireMockInspector",
+                innerException: e
+            );
+        }
+    }
+}

--- a/src/WireMock.Net.Aspire/WireMockServerBuilderExtensions.cs
+++ b/src/WireMock.Net.Aspire/WireMockServerBuilderExtensions.cs
@@ -58,7 +58,7 @@ public static class WireMockServerBuilderExtensions
             .WithImage(DefaultLinuxImage)
             .WithEnvironment(ctx => ctx.EnvironmentVariables.Add("DOTNET_USE_POLLING_FILE_WATCHER", "1")) // https://khalidabuhakmeh.com/aspnet-docker-gotchas-and-workarounds#configuration-reloads-and-filesystemwatcher
             .WithHttpEndpoint(port: arguments.HttpPort, targetPort: WireMockServerArguments.HttpContainerPort)
-            .WithOpenInspectorCommand();
+            .WithWireMockInspectorCommand();
 
         if (!string.IsNullOrEmpty(arguments.MappingsPath))
         {
@@ -185,7 +185,7 @@ public static class WireMockServerBuilderExtensions
     /// </summary>
     /// <param name="builder">The <see cref="IResourceBuilder{WireMockNetResource}"/>.</param>
     /// <returns></returns>
-    public static IResourceBuilder<WireMockServerResource> WithOpenInspectorCommand(this IResourceBuilder<WireMockServerResource> builder)
+    public static IResourceBuilder<WireMockServerResource> WithWireMockInspectorCommand(this IResourceBuilder<WireMockServerResource> builder)
     {
         Guard.NotNull(builder);
 

--- a/src/WireMock.Net.Aspire/WireMockServerBuilderExtensions.cs
+++ b/src/WireMock.Net.Aspire/WireMockServerBuilderExtensions.cs
@@ -191,15 +191,15 @@ public static class WireMockServerBuilderExtensions
 
         CommandOptions commandOptions = new()
         {
-            Description = "Requires installation of the WireMockInspector tool:\ndotnet tool install WireMockInspector --global --no-cache --ignore-failed-sources",
+            Description = "Requires installation of the WireMockInspector (https://github.com/WireMock-Net/WireMockInspector) tool:\ndotnet tool install WireMockInspector --global --no-cache --ignore-failed-sources",
             UpdateState = OnUpdateResourceState,
             IconName = "BoxSearch",
             IconVariant = IconVariant.Filled
         };
 
         builder.WithCommand(
-            name: "open-inspector",
-            displayName: "Open Inspector",
+            name: "wiremock-inspector",
+            displayName: "WireMock Inspector",
             executeCommand: context => OnRunOpenInspectorCommandAsync(builder),
             commandOptions: commandOptions);
 

--- a/test/WireMock.Net.Aspire.TestAppHost/WireMock.Net.Aspire.TestAppHost.csproj
+++ b/test/WireMock.Net.Aspire.TestAppHost/WireMock.Net.Aspire.TestAppHost.csproj
@@ -1,11 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <IsAspireHost>true</IsAspireHost>
 
         <SignAssembly>true</SignAssembly>
         <AssemblyOriginatorKeyFile>../../src/WireMock.Net/WireMock.Net.snk</AssemblyOriginatorKeyFile>
@@ -18,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.2" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/WireMock.Net.Aspire.Tests/WireMock.Net.Aspire.Tests.csproj
+++ b/test/WireMock.Net.Aspire.Tests/WireMock.Net.Aspire.Tests.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.Testing" Version="8.2.2" />
+        <PackageReference Include="Aspire.Hosting.Testing" Version="9.2.0" />
         <PackageReference Include="Codecov" Version="1.13.0" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>

--- a/test/WireMock.Net.Aspire.Tests/WireMock.Net.Aspire.Tests.csproj
+++ b/test/WireMock.Net.Aspire.Tests/WireMock.Net.Aspire.Tests.csproj
@@ -39,6 +39,8 @@
     </ItemGroup>
 
     <ItemGroup>
+        <Using Include="Aspire.Hosting" />
+        <Using Include="Aspire.Hosting.ApplicationModel" />
         <Using Include="Aspire.Hosting.Testing" />
         <Using Include="Xunit" />
     </ItemGroup>

--- a/test/WireMock.Net.Aspire.Tests/WireMockServerBuilderExtensionsTests.cs
+++ b/test/WireMock.Net.Aspire.Tests/WireMockServerBuilderExtensionsTests.cs
@@ -67,7 +67,7 @@ public class WireMockServerBuilderExtensionsTests
             MappingsPath = null,
             HttpPort = port
         });
-        wiremock.Resource.Annotations.Should().HaveCount(4);
+        wiremock.Resource.Annotations.Should().HaveCount(5);
 
         var containerImageAnnotation = wiremock.Resource.Annotations.OfType<ContainerImageAnnotation>().FirstOrDefault();
         containerImageAnnotation.Should().BeEquivalentTo(new ContainerImageAnnotation
@@ -92,5 +92,7 @@ public class WireMockServerBuilderExtensionsTests
         wiremock.Resource.Annotations.OfType<EnvironmentCallbackAnnotation>().FirstOrDefault().Should().NotBeNull();
 
         wiremock.Resource.Annotations.OfType<CommandLineArgsCallbackAnnotation>().FirstOrDefault().Should().NotBeNull();
+
+        wiremock.Resource.Annotations.OfType<ResourceCommandAnnotation>().FirstOrDefault().Should().NotBeNull();
     }
 }


### PR DESCRIPTION
This will add a new command to the Aspire Dashboard on a WireMock resource to launch the WireMockInspector tool.

Also upgrades Aspire to 9.2.0.

Signed-off-by: Jonathan Mezach <jonathan.mezach@rr-wfm.com>