### PR TITLE
Enable support for WireMock Middleware in Hosted Services

### DIFF
--- a/test/WireMock.Net.Middleware.Tests/IntegrationTests.cs
+++ b/test/WireMock.Net.Middleware.Tests/IntegrationTests.cs
@@ -10,6 +10,7 @@ public class IntegrationTests
     [Theory]
     [InlineData("/real1", "Hello 1 from WireMock.Net !")]
     [InlineData("/real2", "Hello 2 from WireMock.Net !")]
+    [InlineData("/real3", "Hello 3 from WireMock.Net !")]
     public async Task CallingRealApi_WithAlwaysRedirectToWireMockIsTrue(string requestUri, string expectedResponse)
     {
         // Arrange

--- a/test/WireMock.Net.TestWebApplication/TaskQueue.cs
+++ b/test/WireMock.Net.TestWebApplication/TaskQueue.cs
@@ -1,0 +1,38 @@
+// Copyright © WireMock.Net
+
+using System.Threading.Channels;
+
+namespace WireMock.Net.TestWebApplication;
+
+public class TaskQueue
+{
+    private enum Status
+    {
+        Success,
+        Error
+    }
+
+    private readonly Channel<string> _taskChannel = Channel.CreateUnbounded<string>();
+    private readonly Channel<(Status, string)> _responseChannel = Channel.CreateUnbounded<(Status, string)>();
+
+    public async Task<string> Enqueue(string taskId, CancellationToken cancellationToken)
+    {
+        await _taskChannel.Writer.WriteAsync(taskId, cancellationToken);
+        var (status, result) = await _responseChannel.Reader.ReadAsync(cancellationToken);
+        if (status == Status.Error)
+        {
+            throw new InvalidOperationException($"Received an error response from the task processor: ${result}");
+        }
+
+        return result;
+    }
+
+    public IAsyncEnumerable<string> ReadTasks(CancellationToken stoppingToken) =>
+        _taskChannel.Reader.ReadAllAsync(stoppingToken);
+
+    public async Task WriteResponse(string result, CancellationToken stoppingToken) =>
+        await _responseChannel.Writer.WriteAsync((Status.Success, result), stoppingToken);
+
+    public async Task WriteErrorResponse(string result, CancellationToken stoppingToken) =>
+        await _responseChannel.Writer.WriteAsync((Status.Error, result), stoppingToken);
+}

--- a/test/WireMock.Net.TestWebApplication/TestBackgroundService.cs
+++ b/test/WireMock.Net.TestWebApplication/TestBackgroundService.cs
@@ -1,0 +1,24 @@
+// Copyright © WireMock.Net
+
+namespace WireMock.Net.TestWebApplication;
+
+public class TestBackgroundService(HttpClient client, TaskQueue taskQueue, ILogger<TestBackgroundService> logger)
+    : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        await foreach (var item in taskQueue.ReadTasks(stoppingToken))
+        {
+            try
+            {
+                var result = await client.GetStringAsync(item, stoppingToken);
+                await taskQueue.WriteResponse(result, stoppingToken);
+            }
+            catch (ArgumentNullException argNullEx)
+            {
+                logger.LogError(argNullEx, "Null exception");
+                await taskQueue.WriteErrorResponse(argNullEx.Message, stoppingToken);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Background

While attempting to use Wiremock Middle in an application that uses hosted services i noticed that it breaks and throws an `ArgumentNullException` .

See #1284 

# Problem 

The problem is that `IHttpContextAccessor.HttpContext` can not be relied upon to always be available.

It would be best if `WireMockDelegationHandler` can fallback gracefully if `HttpContext` is null, which is expected in some cases.

# Solution

I changed `IsWireMockRedirectHeaderSetToTrue` and `TryGetDelayHeaderValue` in `WireMockDelegationHandler` to default to false if `HttpContext` is null.

I created a test to check that it works when started in a hosted service.

# Limitations

The `X-WireMock-Redirect` and `X-WireMock-Response-Delay` headers are obviously not going to work as expected when mocking a request from a background service, maybe this needs to be documented somewhere.
