### PR TITLE
Set description when converting MappingModel to IRespondWithAProvider

### DIFF
--- a/src/WireMock.Net.Minimal/Server/WireMockServer.ConvertMapping.cs
+++ b/src/WireMock.Net.Minimal/Server/WireMockServer.ConvertMapping.cs
@@ -76,6 +76,11 @@ public partial class WireMockServer
             respondProvider = respondProvider.WithTitle(mappingModel.Title!);
         }
 
+        if (!string.IsNullOrEmpty(mappingModel.Description))
+        {
+            respondProvider = respondProvider.WithDescription(mappingModel.Description!);
+        }
+
         if (mappingModel.Priority != null)
         {
             respondProvider = respondProvider.AtPriority(mappingModel.Priority.Value);

--- a/test/WireMock.Net.Tests/AdminApi/WireMockAdminApiTests.PostMappings.cs
+++ b/test/WireMock.Net.Tests/AdminApi/WireMockAdminApiTests.PostMappings.cs
@@ -62,13 +62,15 @@ public partial class WireMockAdminApiTests
         {
             Request = new RequestModel { Path = "/1" },
             Response = new ResponseModel { Body = "txt 1" },
-            Title = "test 1"
+            Title = "test 1",
+            Description = "description 1"
         };
         var model2 = new MappingModel
         {
             Request = new RequestModel { Path = "/2" },
             Response = new ResponseModel { Body = "txt 2" },
-            Title = "test 2"
+            Title = "test 2",
+            Description = "description 2"
         };
         var result = await api.PostMappingsAsync(new[] { model1, model2 }).ConfigureAwait(false);
 
@@ -77,6 +79,8 @@ public partial class WireMockAdminApiTests
         Check.That(result.Status).IsNotNull();
         Check.That(result.Guid).IsNull();
         Check.That(server.Mappings.Where(m => !m.IsAdminInterface)).HasSize(2);
+        Check.That(server.Mappings.Single(x => x.Title == "test 1").Description).IsEqualTo("description 1");
+        Check.That(server.Mappings.Single(x => x.Title == "test 2").Description).IsEqualTo("description 2");
 
         server.Stop();
     }


### PR DESCRIPTION
Adding a mapping with a description to `WireMockServer.WithMapping` did not include the description to the resulting `IRespondWithAProvider`, which means that calling `WireMockServer.SavePact` does not populate the description in the contract file.

This PR includes the description when mapping from `MappingModel` to `IRespondWithAProvider`.

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
