### PR TITLE
Support Testcontainers 4.8.0

### DIFF
--- a/src/WireMock.Net.Testcontainers/WireMock.Net.Testcontainers.csproj
+++ b/src/WireMock.Net.Testcontainers/WireMock.Net.Testcontainers.csproj
@@ -39,7 +39,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Stef.Validation" Version="0.1.1" />
-        <PackageReference Include="Testcontainers" Version="4.7.0" />
+        <PackageReference Include="Testcontainers" Version="4.8.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/WireMock.Net.Testcontainers/WireMockContainer.cs
+++ b/src/WireMock.Net.Testcontainers/WireMockContainer.cs
@@ -128,12 +128,14 @@ public sealed class WireMockContainer : DockerContainer
     /// </summary>
     /// <param name="source">The source directory or file to be copied.</param>
     /// <param name="target">The target directory path to copy the files to.</param>
+    /// <param name="uid">The user ID to set for the copied file or directory. Defaults to 0 (root).</param>
+    /// <param name="gid">The group ID to set for the copied file or directory. Defaults to 0 (root).</param>
     /// <param name="fileMode">The POSIX file mode permission.</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>A task that completes when the directory or file has been copied.</returns>
-    public new async Task CopyAsync(string source, string target, UnixFileModes fileMode = Unix.FileMode644, CancellationToken ct = default)
+    public new async Task CopyAsync(string source, string target, uint uid = 0, uint gid = 0, UnixFileModes fileMode = Unix.FileMode644, CancellationToken ct = default)
     {
-        await base.CopyAsync(source, target, fileMode, ct);
+        await base.CopyAsync(source, target, uid, gid, fileMode, ct);
 
         if (_configuration.WatchStaticMappings && await PathStartsWithContainerMappingsPath(target))
         {


### PR DESCRIPTION
Make WireMock.Net.Testcontainers compatible with Testcontainers 4.8.0.
Testcontainers 4.8.0 is not binary compatible with 4.7.0. 
Ctor of WireMockConfiguration breaks with a MissingMethodException:
```
System.MissingMethodException : Method not found: 'Void DotNet.Testcontainers.Configurations.ContainerConfiguration..ctor(DotNet.Testcontainers.Images.IImage, System.Func`2<Docker.DotNet.Models.ImageInspectResponse,Boolean>, System.String, System.String, System.String, System.String, System.Collections.Generic.IEnumerable`1<System.String>, DotNet.Testcontainers.Configurations.ComposableEnumerable`1<System.String>, System.Collections.Generic.IReadOnlyDictionary`2<System.String,System.String>, System.Collections.Generic.IReadOnlyDictionary`2<System.String,System.String>, System.Collections.Generic.IReadOnlyDictionary`2<System.String,System.String>, System.Collections.Generic.IEnumerable`1<DotNet.Testcontainers.Configurations.IResourceMapping>, System.Collections.Generic.IEnumerable`1<DotNet.Testcontainers.Containers.IContainer>, System.Collections.Generic.IEnumerable`1<DotNet.Testcontainers.Configurations.IMount>, System.Collections.Generic.IEnumerable`1<DotNet.Testcontainers.Networks.INetwork>, System.Collections.Generic.IEnumerable`1<System.String>, System.Collections.Generic.IEnumerable`1<System.String>, DotNet.Testcontainers.Configurations.IOutputConsumer, System.Collections.Generic.IEnumerable`1<DotNet.Testcontainers.Configurations.WaitStrategy>, System.Func`3<DotNet.Testcontainers.Containers.IContainer,System.Threading.CancellationToken,System.Threading.Tasks.Task>, System.Nullable`1<Boolean>, System.Nullable`1<Boolean>)'.
```
## References

[https://github.com/testcontainers/testcontainers-dotnet/commit/3b4f41851222d5dabe1058bb997025026a94e6aa#diff-42f9d6914c9475812b1c918ce9604fc2db0344b779868718675ea7850510b578](https://github.com/testcontainers/testcontainers-dotnet/commit/3b4f41851222d5dabe1058bb997025026a94e6aa#diff-42f9d6914c9475812b1c918ce9604fc2db0344b779868718675ea7850510b578)

[https://github.com/testcontainers/testcontainers-dotnet/commit/c27a94ba320cad698f7bd05b2f93856c0aebb088#diff-cfb5e3427ad9917120dc63419d9b834390f507ddfeb00dceb2fc1bd6f8d503a5](https://github.com/testcontainers/testcontainers-dotnet/commit/c27a94ba320cad698f7bd05b2f93856c0aebb088#diff-cfb5e3427ad9917120dc63419d9b834390f507ddfeb00dceb2fc1bd6f8d503a5)

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [ ] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
