### PR TITLE
Pass the parameter matchOperator in Request.WithPath to its inner calls

### DIFF
--- a/src/WireMock.Net.Minimal/RequestBuilders/Request.WithPath.cs
+++ b/src/WireMock.Net.Minimal/RequestBuilders/Request.WithPath.cs
@@ -21,7 +21,7 @@ public partial class Request
     {
         Guard.NotNullOrEmpty(matchers);
 
-        _requestMatchers.Add(new RequestMessagePathMatcher(MatchBehaviour.AcceptOnMatch, MatchOperator.Or, matchers));
+        _requestMatchers.Add(new RequestMessagePathMatcher(MatchBehaviour.AcceptOnMatch, matchOperator, matchers));
         return this;
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR fixes #1413 .

## References

#1413

## Submitter checklist

- [X] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [X] The PR request is well described and justified, including the body and the references
- [X] The PR title represents the desired changelog entry
- [X] The repository's code style is followed (see the contributing guide)
- [X] Test coverage that demonstrates that the change works as expected
- [X] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
