### PR TITLE
Fix: Pass AllowedHandlebarsHelpers configuration to Handlebars.Net.Helpers library

### DIFF
--- a/src/WireMock.Net.Minimal/Transformers/Handlebars/WireMockHandlebarsHelpers.cs
+++ b/src/WireMock.Net.Minimal/Transformers/Handlebars/WireMockHandlebarsHelpers.cs
@@ -39,6 +39,8 @@ internal static class WireMockHandlebarsHelpers
 #endif
             o.CustomHelperPaths = paths;
 
+            o.Categories = settings.HandlebarsSettings?.AllowedHandlebarsHelpers ?? HandlebarsSettings.DefaultAllowedHandlebarsHelpers;
+
             o.CustomHelpers = new Dictionary<string, IHelpers>();
             if (settings.HandlebarsSettings?.AllowedCustomHandlebarsHelpers.HasFlag(CustomHandlebarsHelpers.File) == true)
             {

--- a/test/WireMock.Net.Tests/Settings/HandlebarsSettingsTests.cs
+++ b/test/WireMock.Net.Tests/Settings/HandlebarsSettingsTests.cs
@@ -1,0 +1,91 @@
+// Copyright © WireMock.Net
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using HandlebarsDotNet;
+using HandlebarsDotNet.Helpers.Enums;
+using Moq;
+using NFluent;
+using WireMock.Handlers;
+using WireMock.Models;
+using WireMock.ResponseBuilders;
+using WireMock.Settings;
+using Xunit;
+
+namespace WireMock.Net.Tests.Settings;
+
+public class HandlebarsSettingsTests
+{
+    private const string ClientIp = "::1";
+
+    private readonly WireMockServerSettings _settings;
+    private readonly Mock<IMapping> _mappingMock;
+    private readonly Mock<IFileSystemHandler> _fileSystemHandlerMock;
+
+    public HandlebarsSettingsTests()
+    {
+        _mappingMock = new Mock<IMapping>();
+
+        _fileSystemHandlerMock = new Mock<IFileSystemHandler>(MockBehavior.Strict);
+
+        _settings = new WireMockServerSettings
+        {
+            FileSystemHandler = _fileSystemHandlerMock.Object
+        };
+    }
+
+    [Fact]
+    public async Task Response_HandlebarsHelpers_Environment_NotAllowed_By_Default()
+    {
+        // Arrange
+        var request = new RequestMessage(new UrlDetails("http://localhost:1234"), "GET", ClientIp);
+
+        var responseBuilder = Response.Create()
+            .WithBody("Username: {{Environment.GetEnvironmentVariable \"USERNAME\"}}")
+            .WithTransformer();
+
+        // Act
+        Func<Task> action = () => responseBuilder.ProvideResponseAsync(_mappingMock.Object, request, _settings);
+
+        // Assert
+        action.Should().ThrowAsync<HandlebarsRuntimeException>();
+    }
+
+    [Fact]
+    public async Task Response_HandlebarsHelpers_Environment_Allowed_When_Configured()
+    {
+        // Arrange
+        var settingsWithEnv = new WireMockServerSettings
+        {
+            FileSystemHandler = _fileSystemHandlerMock.Object,
+            HandlebarsSettings = new HandlebarsSettings
+            {
+                AllowedHandlebarsHelpers = HandlebarsSettings.DefaultAllowedHandlebarsHelpers
+                    .Concat(new[] { Category.Environment })
+                    .ToArray()
+            }
+        };
+
+        var request = new RequestMessage(new UrlDetails("http://localhost:1234"), "GET", ClientIp);
+
+        var responseBuilder = Response.Create()
+            .WithBody("User: {{Environment.GetEnvironmentVariable \"USERNAME\"}}")
+            .WithTransformer();
+
+        // Act
+        var response = await responseBuilder.ProvideResponseAsync(_mappingMock.Object, request, settingsWithEnv).ConfigureAwait(false);
+
+        // Assert
+        Check.That(response.Message.BodyData.BodyAsString).Not.Contains("{{Environment.GetEnvironmentVariable");
+        Check.That(response.Message.BodyData.BodyAsString).StartsWith("User: ");
+    }
+
+    [Fact]
+    public void DefaultAllowedHandlebarsHelpers_Should_Not_Include_Environment()
+    {
+        // Assert
+        Check.That(HandlebarsSettings.DefaultAllowedHandlebarsHelpers).Not.Contains(Category.Environment);
+    }
+}


### PR DESCRIPTION
Bug: The HandlebarsSettings.AllowedHandlebarsHelpers configuration is ignored when trying to enable the Environment helper as documented here https://github.com/wiremock/WireMock.Net?tab=readme-ov-file#handlebarsnet-environment-helper

Repro steps can be found in the associated bug 1415

Fix: This PR is a one line change which passes the AllowedHandlebarsHelpers configuration to Handlebars.Net.Helpers so that optional handlebars helpers can be enabled.

## References

https://github.com/wiremock/WireMock.Net/issues/1415
https://github.com/wiremock/WireMock.Net/issues/1410

## Submitter checklist

- [will do] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [bugfix] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
