### PR TITLE
Update aspire to 13.1 (examples + code)

### DIFF
--- a/examples-Aspire/AspireApp1.AppHost/AspireApp1.AppHost.csproj
+++ b/examples-Aspire/AspireApp1.AppHost/AspireApp1.AppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+    <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -18,7 +18,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/examples-Aspire/AspireApp1.AppHostOriginal/AspireApp1.AppHostOriginal.csproj
+++ b/examples-Aspire/AspireApp1.AppHostOriginal/AspireApp1.AppHostOriginal.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+    <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -15,7 +15,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
     </ItemGroup>
 
 </Project>

--- a/examples-Aspire/AspireApp1.Tests/AspireApp1.Tests.csproj
+++ b/examples-Aspire/AspireApp1.Tests/AspireApp1.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Aspire.Hosting.Testing" Version="8.0.0" />
+    <PackageReference Include="Aspire.Hosting.Testing" Version="13.1.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/src/WireMock.Net.Aspire/WireMock.Net.Aspire.csproj
+++ b/src/WireMock.Net.Aspire/WireMock.Net.Aspire.csproj
@@ -45,7 +45,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting" Version="9.2.0" />
+        <PackageReference Include="Aspire.Hosting" Version="13.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/WireMock.Net.Aspire.TestAppHost/WireMock.Net.Aspire.TestAppHost.csproj
+++ b/test/WireMock.Net.Aspire.TestAppHost/WireMock.Net.Aspire.TestAppHost.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
+    <Sdk Name="Aspire.AppHost.Sdk" Version="13.1.0" />
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -19,7 +19,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="9.2.0" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.1.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/test/WireMock.Net.Aspire.Tests/WireMock.Net.Aspire.Tests.csproj
+++ b/test/WireMock.Net.Aspire.Tests/WireMock.Net.Aspire.Tests.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.Testing" Version="9.2.0" />
+        <PackageReference Include="Aspire.Hosting.Testing" Version="13.1.0" />
         <PackageReference Include="Codecov" Version="1.13.0" />
         <PackageReference Include="coverlet.msbuild" Version="6.0.2">
             <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Allows usage of aspire CLI which is very useful for dev in codespaces (for my next PR).

Updates Wiremock aspire integration & example projects to a new enough version so that Aspire CLI works. 
(there are currently some issues, but that's on Aspire: https://github.com/dotnet/aspire/issues/13817)

## Submitter checklist

- [x] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/wiremock/.github/blob/main/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
