### PR TITLE
Add helpers for query params fluent MappingModelBuilder

### DIFF
--- a/examples/WireMock.Net.Client/Program.cs
+++ b/examples/WireMock.Net.Client/Program.cs
@@ -82,6 +82,21 @@ class Program
             )
         );
 
+        mappingBuilder.Given(m => m
+            .WithRequest(req => req
+                .WithPath("/testWithQueryParams")
+                .UsingGet()
+                .WithParams(p => p.WithParam("param1", pb => pb.WithExactMatcher("value1")))
+            ).WithResponse(rsp => rsp
+                .WithHeaders(h => h.Add("Content-Type", "application/json"))
+                .WithStatusCode(200)
+                .WithBodyAsJson(new
+                {
+                    status = "ok"
+                }, true)
+            )
+        );
+
         var result = await mappingBuilder.BuildAndPostAsync().ConfigureAwait(false);
         Console.WriteLine($"result = {JsonConvert.SerializeObject(result)}");
 

--- a/examples/WireMock.Net.Client/Program.cs
+++ b/examples/WireMock.Net.Client/Program.cs
@@ -84,9 +84,39 @@ class Program
 
         mappingBuilder.Given(m => m
             .WithRequest(req => req
-                .WithPath("/testWithQueryParams")
+                .WithPath("/testRequestWithQueryParams")
                 .UsingGet()
                 .WithParams(p => p.WithParam("param1", pb => pb.WithExactMatcher("value1")))
+            ).WithResponse(rsp => rsp
+                .WithHeaders(h => h.Add("Content-Type", "application/json"))
+                .WithStatusCode(200)
+                .WithBodyAsJson(new
+                {
+                    status = "ok"
+                }, true)
+            )
+        );
+
+        mappingBuilder.Given(m => m
+            .WithRequest(req => req
+                .WithPath("/testRequestWithHeaders")
+                .UsingGet()
+                .WithHeaders(h => h.WithHeader("Accept", hb => hb.WithExactMatcher("application/json")))
+            ).WithResponse(rsp => rsp
+                .WithHeaders(h => h.Add("Content-Type", "application/json"))
+                .WithStatusCode(200)
+                .WithBodyAsJson(new
+                {
+                    status = "ok"
+                }, true)
+            )
+        );
+
+        mappingBuilder.Given(m => m
+            .WithRequest(req => req
+                .WithPath("/testRequestWithCookie")
+                .UsingGet()
+                .WithCookies(c => c.WithCookie("cookie1", cb => cb.WithExactMatcher("cookievalue1")))
             ).WithResponse(rsp => rsp
                 .WithHeaders(h => h.Add("Content-Type", "application/json"))
                 .WithStatusCode(200)

--- a/src/WireMock.Net.Abstractions/BuilderExtensions/ArrayMatcherModelBuilder.cs
+++ b/src/WireMock.Net.Abstractions/BuilderExtensions/ArrayMatcherModelBuilder.cs
@@ -1,0 +1,39 @@
+// Copyright © WireMock.Net
+
+namespace WireMock.Admin.Mappings;
+
+public partial class ArrayMatcherModelBuilder
+{
+    public ArrayMatcherModelBuilder WithExactMatcher(object pattern, bool rejectOnMatch = false, bool ignoreCase = false)
+    {
+        return WithMatcher("ExactMatcher", pattern, rejectOnMatch, ignoreCase);
+    }
+
+    public ArrayMatcherModelBuilder WithWildcardMatcher(object pattern, bool rejectOnMatch = false, bool ignoreCase = false)
+    {
+        return WithMatcher("WildcardMatcher", pattern, rejectOnMatch, ignoreCase);
+    }
+
+    public ArrayMatcherModelBuilder WithRegexMatcher(object pattern, bool rejectOnMatch = false, bool ignoreCase = false)
+    {
+        return WithMatcher("RegexMatcher", pattern, rejectOnMatch, ignoreCase);
+    }
+
+    public ArrayMatcherModelBuilder WithNotNullOrEmptyMatcher(bool rejectOnMatch = false)
+    {
+        return Add(mb => mb
+            .WithName("NotNullOrEmptyMatcher")
+            .WithRejectOnMatch(rejectOnMatch)
+        );
+    }
+
+    private ArrayMatcherModelBuilder WithMatcher(string name, object pattern, bool rejectOnMatch, bool ignoreCase = false)
+    {
+        return Add(mb => mb
+            .WithName(name)
+            .WithPattern(pattern)
+            .WithRejectOnMatch(rejectOnMatch)
+            .WithIgnoreCase(ignoreCase)
+        );
+    }
+}

--- a/src/WireMock.Net.Abstractions/BuilderExtensions/IListCookieModelBuilder.cs
+++ b/src/WireMock.Net.Abstractions/BuilderExtensions/IListCookieModelBuilder.cs
@@ -1,0 +1,19 @@
+// Copyright © WireMock.Net
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WireMock.Admin.Mappings;
+
+public partial class IListCookieModelBuilder
+{
+    public IListCookieModelBuilder WithCookie(string name, Action<IListMatcherModelBuilder> action, bool rejectOnMatch = false)
+    {
+        return Add(cookieBuilder => cookieBuilder
+            .WithName(name)
+            .WithRejectOnMatch(rejectOnMatch)
+            .WithMatchers(matchersBuilder => action(matchersBuilder))
+        );
+    }
+}

--- a/src/WireMock.Net.Abstractions/BuilderExtensions/IListHeaderModelBuilder.cs
+++ b/src/WireMock.Net.Abstractions/BuilderExtensions/IListHeaderModelBuilder.cs
@@ -1,0 +1,19 @@
+// Copyright © WireMock.Net
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace WireMock.Admin.Mappings;
+
+public partial class IListHeaderModelBuilder
+{
+    public IListHeaderModelBuilder WithHeader(string name, Action<IListMatcherModelBuilder> action, bool rejectOnMatch = false)
+    {
+        return Add(headerBuilder => headerBuilder
+            .WithName(name)
+            .WithRejectOnMatch(rejectOnMatch)
+            .WithMatchers(matchersBuilder => action(matchersBuilder))
+        );
+    }
+}

--- a/src/WireMock.Net.Abstractions/BuilderExtensions/IListMatcherModelBuilder.cs
+++ b/src/WireMock.Net.Abstractions/BuilderExtensions/IListMatcherModelBuilder.cs
@@ -1,0 +1,39 @@
+// Copyright © WireMock.Net
+
+namespace WireMock.Admin.Mappings;
+
+public partial class IListMatcherModelBuilder
+{
+    public IListMatcherModelBuilder WithExactMatcher(object pattern, bool rejectOnMatch = false, bool ignoreCase = false)
+    {
+        return WithMatcher("ExactMatcher", pattern, rejectOnMatch, ignoreCase);
+    }
+
+    public IListMatcherModelBuilder WithWildcardMatcher(object pattern, bool rejectOnMatch = false, bool ignoreCase = false)
+    {
+        return WithMatcher("WildcardMatcher", pattern, rejectOnMatch, ignoreCase);
+    }
+
+    public IListMatcherModelBuilder WithRegexMatcher(object pattern, bool rejectOnMatch = false, bool ignoreCase = false)
+    {
+        return WithMatcher("RegexMatcher", pattern, rejectOnMatch, ignoreCase);
+    }
+
+    public IListMatcherModelBuilder WithNotNullOrEmptyMatcher(bool rejectOnMatch = false)
+    {
+        return Add(mb => mb
+            .WithName("NotNullOrEmptyMatcher")
+            .WithRejectOnMatch(rejectOnMatch)
+        );
+    }
+
+    private IListMatcherModelBuilder WithMatcher(string name, object pattern, bool rejectOnMatch, bool ignoreCase = false)
+    {
+        return Add(mb => mb
+            .WithName(name)
+            .WithPattern(pattern)
+            .WithRejectOnMatch(rejectOnMatch)
+            .WithIgnoreCase(ignoreCase)
+        );
+    }
+}

--- a/src/WireMock.Net.Abstractions/BuilderExtensions/IListParamModelBuilder.cs
+++ b/src/WireMock.Net.Abstractions/BuilderExtensions/IListParamModelBuilder.cs
@@ -1,0 +1,17 @@
+// Copyright © WireMock.Net
+
+using System;
+
+namespace WireMock.Admin.Mappings;
+
+public partial class IListParamModelBuilder
+{
+    public IListParamModelBuilder WithParam(string name, Action<ArrayMatcherModelBuilder> action, bool rejectOnMatch = false)
+    {
+        return Add(paramBuilder => paramBuilder
+            .WithName(name)
+            .WithRejectOnMatch(rejectOnMatch)
+            .WithMatchers(matchersBuilder => action(matchersBuilder))
+        );
+    }
+}


### PR DESCRIPTION
This PR adds some helper methods to improve the fluent API syntax when adding query params.

I found that adding query parameters with the fluent API was really tedious, compared to how easy it is to set up a body matcher. 

For example, if I wanted to match a request to `/api/weather?city=Amsterdam` the code might look something like this:
```csharp
Given(m => m
  .WithRequest(r => r
    .UsingGet()
    .WithPath("/api/weather")
    .WithParams(pb =>pb
      .Add(p => p
        .WithName("city")
        .WithMatchers(mb => mb
          .Add(m => m
            .WithName("ExactMatcher")
            .WithPattern("Amsterdam")
          )
        )
      )
    )
  )
);
```

Really long and verbose.

With this PR, we can shorten it to:
```csharp
Given(m => m
  .WithRequest(r => r
    .UsingGet()
    .WithPath("/api/weather")
    .WithParams(pb => pb
      pb.WithParam("city", mb => mb.WithExactMatcher("Amsterdam"))
    )
  )
);
```