### PR TITLE
Feature/early mismatch

### DIFF
--- a/src/WireMock.Net.Abstractions/Admin/Mappings/RequestModel.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/RequestModel.cs
@@ -1,5 +1,7 @@
 // Copyright © WireMock.Net
 
+using WireMock.Matchers.Request;
+
 namespace WireMock.Admin.Mappings;
 
 /// <summary>
@@ -71,5 +73,5 @@ public class RequestModel
     /// Type of the request matcher to return an immediate mismatch during mapping processing.
     /// Optional.
     /// </summary>
-    public string? EarlyMatcherType { get; set; }
+    public RequestMatcherType? EarlyMatcherType { get; set; }
 }

--- a/src/WireMock.Net.Abstractions/Admin/Mappings/RequestModel.cs
+++ b/src/WireMock.Net.Abstractions/Admin/Mappings/RequestModel.cs
@@ -61,9 +61,15 @@ public class RequestModel
     /// Gets or sets the Params.
     /// </summary>
     public IList<ParamModel>? Params { get; set; }
-        
+
     /// <summary>
     /// Gets or sets the body.
     /// </summary>
     public BodyModel? Body { get; set; }
+
+    /// <summary>
+    /// Type of the request matcher to return an immediate mismatch during mapping processing.
+    /// Optional.
+    /// </summary>
+    public string? EarlyMatcherType { get; set; }
 }

--- a/src/WireMock.Net.Abstractions/Matchers/Request/IRequestMatcher.cs
+++ b/src/WireMock.Net.Abstractions/Matchers/Request/IRequestMatcher.cs
@@ -8,6 +8,11 @@ namespace WireMock.Matchers.Request;
 public interface IRequestMatcher
 {
     /// <summary>
+    /// Gets the request matcher's type.
+    /// </summary>
+    public RequestMatcherType Type { get; }
+
+    /// <summary>
     /// Determines whether the specified RequestMessage is match.
     /// </summary>
     /// <param name="requestMessage">The RequestMessage.</param>

--- a/src/WireMock.Net.Abstractions/Matchers/Request/RequestMatcherType.cs
+++ b/src/WireMock.Net.Abstractions/Matchers/Request/RequestMatcherType.cs
@@ -1,0 +1,84 @@
+﻿// Copyright © WireMock.Net
+
+namespace WireMock.Matchers.Request;
+
+/// <summary>
+/// List of predefined request matcher types.
+/// </summary>
+public enum RequestMatcherType
+{
+    /// <summary>
+    /// RequestMessageBodyMatcher
+    /// </summary>
+    Body = 0,
+
+    /// <summary>
+    /// RequestMessageBodyMatcher{T}
+    /// </summary>
+    BodyOfT = 1,
+
+    /// <summary>
+    /// RequestMessageClientIPMatcher
+    /// </summary>
+    ClientIP = 2,
+
+    /// <summary>
+    /// RequestMessageCookieMatcher
+    /// </summary>
+    Cookie = 3,
+
+    /// <summary>
+    /// RequestMessageGraphQLMatcher
+    /// </summary>
+    GraphQL = 4,
+
+    /// <summary>
+    /// RequestMessageHeaderMatcher
+    /// </summary>
+    Header = 5,
+
+    /// <summary>
+    /// RequestMessageHttpVersionMatcher
+    /// </summary>
+    HttpVersion = 6,
+
+    /// <summary>
+    /// RequestMessageMethodMatcher
+    /// </summary>
+    Method = 7,
+
+    /// <summary>
+    /// RequestMessageMultiPartMatcher
+    /// </summary>
+    MultiPart = 8,
+
+    /// <summary>
+    /// RequestMessageParamMatcher
+    /// </summary>
+    Param = 9,
+
+    /// <summary>
+    /// RequestMessagePathMatcher
+    /// </summary>
+    Path = 10,
+
+    /// <summary>
+    /// RequestMessageProtoBufMatcher
+    /// </summary>
+    ProtoBuf = 11,
+
+    /// <summary>
+    /// RequestMessageScenarioAndStateMatcher
+    /// </summary>
+    ScenarioAndState = 12,
+
+    /// <summary>
+    /// RequestMessageUrlMatcher
+    /// </summary>
+    Url = 13,
+
+    /// <summary>
+    /// RequestMessageCompositeMatcher
+    /// </summary>
+    Composite = 14
+}

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageBodyMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageBodyMatcher.cs
@@ -143,6 +143,9 @@ public class RequestMessageBodyMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.Body;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var (score, exception) = CalculateMatchResult(requestMessage).Expand();

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageBodyMatcher`1.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageBodyMatcher`1.cs
@@ -32,6 +32,9 @@ public class RequestMessageBodyMatcher<T> : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.BodyOfT;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var (score, exception) = CalculateMatchScore(requestMessage).Expand();

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageClientIPMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageClientIPMatcher.cs
@@ -75,6 +75,9 @@ public class RequestMessageClientIPMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.ClientIP;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var matchDetail = GetMatchResult(requestMessage).ToMatchDetail();

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
@@ -37,6 +37,9 @@ public abstract class RequestMessageCompositeMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.Composite;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         if (!RequestMatchers.Any())

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
@@ -23,7 +23,7 @@ public abstract class RequestMessageCompositeMatcher : IRequestMatcher
     /// <summary>
     /// Selected type to choose the matcher from <see cref="RequestMatchers"/> which will immediately return a mismatch.
     /// </summary>
-    protected RequestMatcherType? EarlyMatcherType = null;
+    internal RequestMatcherType? EarlyMatcherType { get; private protected set; } = null;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestMessageCompositeMatcher"/> class.

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
@@ -23,7 +23,7 @@ public abstract class RequestMessageCompositeMatcher : IRequestMatcher
     /// <summary>
     /// Selected type to choose the matcher from <see cref="RequestMatchers"/> which will immediately return a mismatch.
     /// </summary>
-    internal RequestMatcherType? EarlyMatcherType { get; private protected set; } = null;
+    internal RequestMatcherType? EarlyMatcherType { get; private protected set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestMessageCompositeMatcher"/> class.
@@ -47,10 +47,8 @@ public abstract class RequestMessageCompositeMatcher : IRequestMatcher
             return MatchScores.Mismatch;
         }
 
-        var earlyMatcher = EarlyMatcherType is null
-            ? null
-            : RequestMatchers.FirstOrDefault(m => m.Type == EarlyMatcherType);
-        var earlyMatchResult = earlyMatcher?.GetMatchingScore(requestMessage, requestMatchResult) ?? MatchScores.Perfect;
+        var earlyMatcher = new RequestMessageEarlyMatcher(EarlyMatcherType, RequestMatchers);
+        var earlyMatchResult = earlyMatcher.GetMatchingScore(requestMessage, requestMatchResult);
         if (!MatchScores.IsPerfect(earlyMatchResult))
         {
             return MatchScores.Mismatch;

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
@@ -21,9 +21,9 @@ public abstract class RequestMessageCompositeMatcher : IRequestMatcher
     private IEnumerable<IRequestMatcher> RequestMatchers { get; }
 
     /// <summary>
-    /// Function to select the matcher from <see cref="RequestMatchers"/> which will immediately return a mismatch.
+    /// Selected type to choose the matcher from <see cref="RequestMatchers"/> which will immediately return a mismatch.
     /// </summary>
-    protected Func<IEnumerable<IRequestMatcher>, IRequestMatcher?>? EarlyMatcherSelector = null;
+    protected RequestMatcherType? EarlyMatcherType = null;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestMessageCompositeMatcher"/> class.
@@ -47,7 +47,9 @@ public abstract class RequestMessageCompositeMatcher : IRequestMatcher
             return MatchScores.Mismatch;
         }
 
-        var earlyMatcher = EarlyMatcherSelector?.Invoke(RequestMatchers);
+        var earlyMatcher = EarlyMatcherType is null
+            ? null
+            : RequestMatchers.FirstOrDefault(m => m.Type == EarlyMatcherType);
         var earlyMatchResult = earlyMatcher?.GetMatchingScore(requestMessage, requestMatchResult) ?? MatchScores.Perfect;
         if (!MatchScores.IsPerfect(earlyMatchResult))
         {

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCompositeMatcher.cs
@@ -21,6 +21,11 @@ public abstract class RequestMessageCompositeMatcher : IRequestMatcher
     private IEnumerable<IRequestMatcher> RequestMatchers { get; }
 
     /// <summary>
+    /// Function to select the matcher from <see cref="RequestMatchers"/> which will immediately return a mismatch.
+    /// </summary>
+    protected Func<IEnumerable<IRequestMatcher>, IRequestMatcher?>? EarlyMatcherSelector = null;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="RequestMessageCompositeMatcher"/> class.
     /// </summary>
     /// <param name="requestMatchers">The request matchers.</param>
@@ -35,6 +40,13 @@ public abstract class RequestMessageCompositeMatcher : IRequestMatcher
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         if (!RequestMatchers.Any())
+        {
+            return MatchScores.Mismatch;
+        }
+
+        var earlyMatcher = EarlyMatcherSelector?.Invoke(RequestMatchers);
+        var earlyMatchResult = earlyMatcher?.GetMatchingScore(requestMessage, requestMatchResult) ?? MatchScores.Perfect;
+        if (!MatchScores.IsPerfect(earlyMatchResult))
         {
             return MatchScores.Mismatch;
         }

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCookieMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageCookieMatcher.cs
@@ -94,6 +94,9 @@ public class RequestMessageCookieMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.Cookie;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var (score, exception) = GetMatchResult(requestMessage).Expand();

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageEarlyMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageEarlyMatcher.cs
@@ -1,0 +1,31 @@
+﻿// Copyright © WireMock.Net
+
+namespace WireMock.Matchers.Request;
+
+/// <summary>
+/// Return the mismatch if the matching score of matchers is not perfect.
+/// </summary>
+internal sealed class RequestMessageEarlyMatcher(
+    RequestMatcherType? earlyMatcherType,
+    IEnumerable<IRequestMatcher> requestMatchers) : IRequestMatcher
+{
+    /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.Composite;
+
+    /// <inheritdoc />
+    public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
+    {
+        if (earlyMatcherType is null)
+            return MatchScores.Perfect;
+
+        var earlyMatchers = requestMatchers
+            .Where(m => m.Type == earlyMatcherType)
+            .ToList();
+
+        if (earlyMatchers is [])
+            return MatchScores.Perfect;
+
+        var compositeMatcher = new RequestBuilders.Request(earlyMatchers);
+        return compositeMatcher.GetMatchingScore(requestMessage, requestMatchResult);
+    }
+}

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageEarlyMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageEarlyMatcher.cs
@@ -22,7 +22,7 @@ internal sealed class RequestMessageEarlyMatcher(
             .Where(m => m.Type == earlyMatcherType)
             .ToList();
 
-        if (earlyMatchers is [])
+        if (earlyMatchers.Count is 0)
             return MatchScores.Perfect;
 
         var compositeMatcher = new RequestBuilders.Request(earlyMatchers);

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageEarlyMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageEarlyMatcher.cs
@@ -16,14 +16,18 @@ internal sealed class RequestMessageEarlyMatcher(
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         if (earlyMatcherType is null)
+        {
             return MatchScores.Perfect;
+        }
 
         var earlyMatchers = requestMatchers
             .Where(m => m.Type == earlyMatcherType)
             .ToList();
 
         if (earlyMatchers.Count is 0)
+        {
             return MatchScores.Perfect;
+        }
 
         var compositeMatcher = new RequestBuilders.Request(earlyMatchers);
         return compositeMatcher.GetMatchingScore(requestMessage, requestMatchResult);

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageHeaderMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageHeaderMatcher.cs
@@ -107,6 +107,9 @@ public class RequestMessageHeaderMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.Header;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var (score, exception) = GetMatchResult(requestMessage).Expand();

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageHttpVersionMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageHttpVersionMatcher.cs
@@ -66,6 +66,9 @@ public class RequestMessageHttpVersionMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.HttpVersion;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var (score, exception) = GetMatchResult(requestMessage).Expand();

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageMethodMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageMethodMatcher.cs
@@ -47,6 +47,9 @@ internal class RequestMessageMethodMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.Method;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var scores = Methods.Select(m => string.Equals(m, requestMessage.Method, StringComparison.OrdinalIgnoreCase)).ToArray();

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageMultiPartMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageMultiPartMatcher.cs
@@ -56,6 +56,9 @@ public class RequestMessageMultiPartMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.MultiPart;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var matchDetail = MatchResult.From(Name).ToMatchDetail();

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageParamMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageParamMatcher.cs
@@ -83,6 +83,9 @@ public class RequestMessageParamMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.Param;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var score = GetMatchScore(requestMessage);

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessagePathMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessagePathMatcher.cs
@@ -73,6 +73,9 @@ public class RequestMessagePathMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.Path;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var matchDetail = GetMatchResult(requestMessage).ToMatchDetail();

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageScenarioAndStateMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageScenarioAndStateMatcher.cs
@@ -30,6 +30,9 @@ internal class RequestMessageScenarioAndStateMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.ScenarioAndState;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         return requestMatchResult.AddScore(GetType(), GetScore(), null);

--- a/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageUrlMatcher.cs
+++ b/src/WireMock.Net.Minimal/Matchers/Request/RequestMessageUrlMatcher.cs
@@ -73,6 +73,9 @@ public class RequestMessageUrlMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.Url;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var (score, exception) = GetMatchResult(requestMessage).Expand();

--- a/src/WireMock.Net.Minimal/RequestBuilders/Request.cs
+++ b/src/WireMock.Net.Minimal/RequestBuilders/Request.cs
@@ -82,10 +82,9 @@ public partial class Request : RequestMessageCompositeMatcher, IRequestBuilder
     }
 
     /// <inheritdoc />
-    public IRequestBuilder WithEarlyMismatch(
-        Func<IEnumerable<IRequestMatcher>, IRequestMatcher?> earlyMatcherSelector)
+    public IRequestBuilder WithEarlyMismatch(RequestMatcherType? earlyMatcherType)
     {
-        EarlyMatcherSelector = earlyMatcherSelector;
+        EarlyMatcherType = earlyMatcherType;
         return this;
     }
 

--- a/src/WireMock.Net.Minimal/RequestBuilders/Request.cs
+++ b/src/WireMock.Net.Minimal/RequestBuilders/Request.cs
@@ -34,7 +34,7 @@ public partial class Request : RequestMessageCompositeMatcher, IRequestBuilder
     /// Initializes a new instance of the <see cref="Request"/> class.
     /// </summary>
     /// <param name="requestMatchers">The request matchers.</param>
-    private Request(IList<IRequestMatcher> requestMatchers) : base(requestMatchers)
+    internal Request(IList<IRequestMatcher> requestMatchers) : base(requestMatchers)
     {
         _requestMatchers = Guard.NotNull(requestMatchers);
     }

--- a/src/WireMock.Net.Minimal/RequestBuilders/Request.cs
+++ b/src/WireMock.Net.Minimal/RequestBuilders/Request.cs
@@ -81,6 +81,14 @@ public partial class Request : RequestMessageCompositeMatcher, IRequestBuilder
         return this;
     }
 
+    /// <inheritdoc />
+    public IRequestBuilder WithEarlyMismatch(
+        Func<IEnumerable<IRequestMatcher>, IRequestMatcher?> earlyMatcherSelector)
+    {
+        EarlyMatcherSelector = earlyMatcherSelector;
+        return this;
+    }
+
     internal bool TryGetProtoBufMatcher([NotNullWhen(true)] out IProtoBufMatcher? protoBufMatcher)
     {
         protoBufMatcher = GetRequestMessageMatcher<RequestMessageProtoBufMatcher>()?.Matcher;

--- a/src/WireMock.Net.Minimal/Serialization/MappingConverter.cs
+++ b/src/WireMock.Net.Minimal/Serialization/MappingConverter.cs
@@ -66,6 +66,12 @@ internal class MappingConverter(MatcherMapper mapper)
 
         // Request
         sb.AppendLine("    .Given(Request.Create()");
+
+        if (request.EarlyMatcherType != null)
+        {
+            sb.AppendLine($"        .WithEarlyMismatch(RequestMatcherType.{request.EarlyMatcherType})");
+        }
+
         sb.AppendLine($"        .UsingMethod({To1Or2Or3Arguments(methodMatcher?.MatchBehaviour, methodMatcher?.MatchOperator, methodMatcher?.Methods, HttpRequestMethod.GET)})");
 
         if (pathMatcher?.Matchers != null)
@@ -300,7 +306,9 @@ internal class MappingConverter(MatcherMapper mapper)
                     IgnoreCase = pm.IgnoreCase ? true : null,
                     RejectOnMatch = pm.MatchBehaviour == MatchBehaviour.RejectOnMatch ? true : null,
                     Matchers = _mapper.Map(pm.Matchers)
-                }).ToList() : null
+                }).ToList() : null,
+
+                EarlyMatcherType = request.EarlyMatcherType?.ToString()
             },
             Response = new ResponseModel()
         };

--- a/src/WireMock.Net.Minimal/Serialization/MappingConverter.cs
+++ b/src/WireMock.Net.Minimal/Serialization/MappingConverter.cs
@@ -69,7 +69,7 @@ internal class MappingConverter(MatcherMapper mapper)
 
         if (request.EarlyMatcherType != null)
         {
-            sb.AppendLine($"        .WithEarlyMismatch(RequestMatcherType.{request.EarlyMatcherType})");
+            sb.AppendLine($"        .WithEarlyMismatch({request.EarlyMatcherType.Value.GetFullyQualifiedEnumValue()})");
         }
 
         sb.AppendLine($"        .UsingMethod({To1Or2Or3Arguments(methodMatcher?.MatchBehaviour, methodMatcher?.MatchOperator, methodMatcher?.Methods, HttpRequestMethod.GET)})");
@@ -308,7 +308,7 @@ internal class MappingConverter(MatcherMapper mapper)
                     Matchers = _mapper.Map(pm.Matchers)
                 }).ToList() : null,
 
-                EarlyMatcherType = request.EarlyMatcherType?.ToString()
+                EarlyMatcherType = request.EarlyMatcherType
             },
             Response = new ResponseModel()
         };

--- a/src/WireMock.Net.Minimal/Server/WireMockServer.ConvertMapping.cs
+++ b/src/WireMock.Net.Minimal/Server/WireMockServer.ConvertMapping.cs
@@ -268,6 +268,9 @@ public partial class WireMockServer
             }
         }
 
+        requestBuilder = requestBuilder.WithEarlyMismatch(
+            StringUtils.ParseRequestMatcherType(requestModel.EarlyMatcherType));
+
         return requestBuilder;
     }
 

--- a/src/WireMock.Net.Minimal/Server/WireMockServer.ConvertMapping.cs
+++ b/src/WireMock.Net.Minimal/Server/WireMockServer.ConvertMapping.cs
@@ -268,8 +268,7 @@ public partial class WireMockServer
             }
         }
 
-        requestBuilder = requestBuilder.WithEarlyMismatch(
-            StringUtils.ParseRequestMatcherType(requestModel.EarlyMatcherType));
+        requestBuilder = requestBuilder.WithEarlyMismatch(requestModel.EarlyMatcherType);
 
         return requestBuilder;
     }

--- a/src/WireMock.Net.Minimal/Util/StringUtils.cs
+++ b/src/WireMock.Net.Minimal/Util/StringUtils.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
 using WireMock.Matchers;
-using WireMock.Matchers.Request;
 
 namespace WireMock.Util;
 
@@ -57,13 +56,6 @@ internal static class StringUtils
         return value != null && Enum.TryParse<MatchOperator>(value, out var matchOperator)
             ? matchOperator
             : MatchOperator.Or;
-    }
-
-    public static RequestMatcherType? ParseRequestMatcherType(string? value)
-    {
-        return !string.IsNullOrWhiteSpace(value) && Enum.TryParse<RequestMatcherType>(value, out var matchOperator)
-            ? matchOperator
-            : null;
     }
 
     public static bool TryParseQuotedString(string? value, [NotNullWhen(true)] out string? result, out char quote)

--- a/src/WireMock.Net.Minimal/Util/StringUtils.cs
+++ b/src/WireMock.Net.Minimal/Util/StringUtils.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text.RegularExpressions;
 using WireMock.Matchers;
+using WireMock.Matchers.Request;
 
 namespace WireMock.Util;
 
@@ -56,6 +57,13 @@ internal static class StringUtils
         return value != null && Enum.TryParse<MatchOperator>(value, out var matchOperator)
             ? matchOperator
             : MatchOperator.Or;
+    }
+
+    public static RequestMatcherType? ParseRequestMatcherType(string? value)
+    {
+        return !string.IsNullOrWhiteSpace(value) && Enum.TryParse<RequestMatcherType>(value, out var matchOperator)
+            ? matchOperator
+            : null;
     }
 
     public static bool TryParseQuotedString(string? value, [NotNullWhen(true)] out string? result, out char quote)

--- a/src/WireMock.Net.Shared/Matchers/Request/RequestMessageGraphQLMatcher.cs
+++ b/src/WireMock.Net.Shared/Matchers/Request/RequestMessageGraphQLMatcher.cs
@@ -70,6 +70,9 @@ public class RequestMessageGraphQLMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.GraphQL;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var results = CalculateMatchResults(requestMessage);

--- a/src/WireMock.Net.Shared/Matchers/Request/RequestMessageProtoBufMatcher.cs
+++ b/src/WireMock.Net.Shared/Matchers/Request/RequestMessageProtoBufMatcher.cs
@@ -31,6 +31,9 @@ public class RequestMessageProtoBufMatcher : IRequestMatcher
     }
 
     /// <inheritdoc />
+    public RequestMatcherType Type => RequestMatcherType.ProtoBuf;
+
+    /// <inheritdoc />
     public double GetMatchingScore(IRequestMessage requestMessage, IRequestMatchResult requestMatchResult)
     {
         var (score, exception) = GetMatchResult(requestMessage).Expand();

--- a/src/WireMock.Net.Shared/RequestBuilders/IRequestBuilder.cs
+++ b/src/WireMock.Net.Shared/RequestBuilders/IRequestBuilder.cs
@@ -23,10 +23,9 @@ public interface IRequestBuilder : IClientIPRequestBuilder
     IMapping Mapping { get; set; }
 
     /// <summary>
-    /// Chooses <see cref="IRequestMatcher"/> which immediately returns a mismatch during mappings enumeration.
+    /// Chooses the <see cref="IRequestMatcher"/> which immediately returns a mismatch during mappings enumeration.
     /// </summary>
-    /// <param name="earlyMatcherSelector">Function to select the matcher from available list.</param>
+    /// <param name="earlyMatcherType">Selected type to choose the matcher from available list.</param>
     /// <returns>The current <see cref="IRequestBuilder"/> instance.</returns>
-    IRequestBuilder WithEarlyMismatch(
-        Func<IEnumerable<IRequestMatcher>, IRequestMatcher?> earlyMatcherSelector);
+    IRequestBuilder WithEarlyMismatch(RequestMatcherType? earlyMatcherType);
 }

--- a/src/WireMock.Net.Shared/RequestBuilders/IRequestBuilder.cs
+++ b/src/WireMock.Net.Shared/RequestBuilders/IRequestBuilder.cs
@@ -10,7 +10,8 @@ namespace WireMock.RequestBuilders;
 public interface IRequestBuilder : IClientIPRequestBuilder
 {
     /// <summary>
-    /// Adds a request matcher to the builder.
+    /// Adds a request matcher to the builder.<br/>
+    /// If the request matcher is already present, it will be replaced.
     /// </summary>
     /// <typeparam name="T">The type of the request matcher.</typeparam>
     /// <param name="requestMatcher">The request matcher to add.</param>

--- a/src/WireMock.Net.Shared/RequestBuilders/IRequestBuilder.cs
+++ b/src/WireMock.Net.Shared/RequestBuilders/IRequestBuilder.cs
@@ -21,4 +21,12 @@ public interface IRequestBuilder : IClientIPRequestBuilder
     /// The link back to the Mapping.
     /// </summary>
     IMapping Mapping { get; set; }
+
+    /// <summary>
+    /// Chooses <see cref="IRequestMatcher"/> which immediately returns a mismatch during mappings enumeration.
+    /// </summary>
+    /// <param name="earlyMatcherSelector">Function to select the matcher from available list.</param>
+    /// <returns>The current <see cref="IRequestBuilder"/> instance.</returns>
+    IRequestBuilder WithEarlyMismatch(
+        Func<IEnumerable<IRequestMatcher>, IRequestMatcher?> earlyMatcherSelector);
 }

--- a/test/WireMock.Net.Tests/Grpc/WireMockServerTests.Grpc.cs
+++ b/test/WireMock.Net.Tests/Grpc/WireMockServerTests.Grpc.cs
@@ -8,8 +8,11 @@ using ExampleIntegrationTest.Lookup;
 using Google.Protobuf.WellKnownTypes;
 using Greet;
 using Grpc.Net.Client;
+using Moq;
 using WireMock.Constants;
 using WireMock.Matchers;
+using WireMock.Matchers.Request;
+using WireMock.Net.Xunit;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -78,7 +81,7 @@ import ""google/protobuf/empty.proto"";
 
 service Greeter {
   rpc Nothing (google.protobuf.Empty) returns (google.protobuf.Empty);
-  
+
   rpc SayHello (HelloRequest) returns (HelloReply);
 
   rpc SayOther (Other) returns (HelloReply);
@@ -729,6 +732,93 @@ message Other {
         var reply = await When_GrpcClient_Calls_SayHelloAsync(server.Urls[1], cancellationToken);
 
         Then_ReplyMessage_Should_BeCorrect(reply);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task WireMockServer_WithBodyAsProtoBuf_WithEarlyMismatch_ErrorLogs_Issue1442(
+        bool withEarlyMismatch)
+    {
+        // Arrange
+        var greeterId = $"test-greeter-{Guid.NewGuid()}";
+        var policyId = $"test-policy-{Guid.NewGuid()}";
+        var ct = TestContext.Current.CancellationToken;
+
+        var greeterProtoDefinition = ProtoDefinition;
+        var policyProtoDefinition = File.ReadAllText("./Grpc/policy.proto");
+
+        var mockTestOutputHelper = new Mock<ITestOutputHelper>();
+        using var server = WireMockServer.Start(new WireMockServerSettings
+        {
+            UseHttp2 = true,
+            Logger = new TestOutputHelperWireMockLogger(mockTestOutputHelper.Object)
+        });
+
+        server
+            .AddProtoDefinition(greeterId, greeterProtoDefinition)
+            .Given(Request.Create()
+                .UsingPost()
+                .WithHttpVersion("2")
+                .WithPath("/greet.Greeter/SayHello")
+                .WithEarlyMismatch(matchers => withEarlyMismatch
+                    ? matchers.OfType<RequestMessagePathMatcher>().FirstOrDefault()
+                    : null)
+                .WithBodyAsProtoBuf("greet.HelloRequest", new JsonMatcher(new { name = "stef" })))
+            .WithProtoDefinition(greeterId)
+            .RespondWith(Response.Create()
+                .WithHeader("Content-Type", "application/grpc")
+                .WithTrailingHeader("grpc-status", "0")
+                .WithBodyAsProtoBuf("greet.HelloReply",
+                    new
+                    {
+                        message = "hello {{request.BodyAsJson.name}} {{request.method}}"
+                    })
+                .WithTransformer());
+
+        server
+            .AddProtoDefinition(policyId, policyProtoDefinition)
+            .Given(Request.Create()
+                .UsingPost()
+                .WithHttpVersion("2")
+                .WithPath("/Policy.PolicyService/GetVersion")
+                .WithEarlyMismatch(matchers => withEarlyMismatch
+                    ? matchers.OfType<RequestMessagePathMatcher>().FirstOrDefault()
+                    : null)
+                .WithBodyAsProtoBuf("ExampleIntegrationTest.Lookup.GetVersionRequest", new NotNullOrEmptyMatcher()))
+            .WithProtoDefinition(policyId)
+            .RespondWith(Response.Create()
+                .WithHeader("Content-Type", "application/grpc")
+                .WithTrailingHeader("grpc-status", "0")
+                .WithBodyAsProtoBuf("ExampleIntegrationTest.Lookup.GetVersionResponse",
+                    new GetVersionResponse
+                    {
+                        Version = "test",
+                        DateHired = new Timestamp
+                        {
+                            Seconds = 1722301323,
+                            Nanos = 12300
+                        },
+                        Client = new ExampleIntegrationTest.Lookup.Client
+                        {
+                            ClientName = ExampleIntegrationTest.Lookup.Client.Types.Clients.Test,
+                            CorrelationId = "correlation"
+                        }
+                    })
+                .WithTransformer());
+
+        // Act
+        var channel = GrpcChannel.ForAddress(server.Url!);
+        var policyServiceClient = new PolicyService.PolicyServiceClient(channel);
+        var greeterClient = new Greeter.GreeterClient(channel);
+
+        _ = await policyServiceClient.GetVersionAsync(new GetVersionRequest(), cancellationToken: ct);
+        _ = await greeterClient.SayHelloAsync(new HelloRequest { Name = "stef" }, cancellationToken: ct);
+
+        mockTestOutputHelper.Verify(
+            x => x.WriteLine(
+                It.Is<string>(log => log.Contains("[Error]") && log.Contains("Exception"))),
+            withEarlyMismatch ? Times.Never : Times.AtLeastOnce);
     }
 
     private static WireMockServer Given_When_ServerStarted_And_RunningOnHttpAndGrpc()

--- a/test/WireMock.Net.Tests/Grpc/WireMockServerTests.Grpc.cs
+++ b/test/WireMock.Net.Tests/Grpc/WireMockServerTests.Grpc.cs
@@ -761,8 +761,8 @@ message Other {
                 .UsingPost()
                 .WithHttpVersion("2")
                 .WithPath("/greet.Greeter/SayHello")
-                .WithEarlyMismatch(matchers => withEarlyMismatch
-                    ? matchers.OfType<RequestMessagePathMatcher>().FirstOrDefault()
+                .WithEarlyMismatch(withEarlyMismatch
+                    ? RequestMatcherType.Path
                     : null)
                 .WithBodyAsProtoBuf("greet.HelloRequest", new JsonMatcher(new { name = "stef" })))
             .WithProtoDefinition(greeterId)
@@ -782,8 +782,8 @@ message Other {
                 .UsingPost()
                 .WithHttpVersion("2")
                 .WithPath("/Policy.PolicyService/GetVersion")
-                .WithEarlyMismatch(matchers => withEarlyMismatch
-                    ? matchers.OfType<RequestMessagePathMatcher>().FirstOrDefault()
+                .WithEarlyMismatch(withEarlyMismatch
+                    ? RequestMatcherType.Path
                     : null)
                 .WithBodyAsProtoBuf("ExampleIntegrationTest.Lookup.GetVersionRequest", new NotNullOrEmptyMatcher()))
             .WithProtoDefinition(policyId)

--- a/test/WireMock.Net.Tests/RequestMatchers/RequestMessageCompositeMatcherTests.cs
+++ b/test/WireMock.Net.Tests/RequestMatchers/RequestMessageCompositeMatcherTests.cs
@@ -14,9 +14,9 @@ public class RequestMessageCompositeMatcherTests
         public Helper(
             IEnumerable<IRequestMatcher> requestMatchers,
             CompositeMatcherType type = CompositeMatcherType.And,
-            Func<IEnumerable<IRequestMatcher>, IRequestMatcher?>? earlyMatcherSelector = null) : base(requestMatchers, type)
+            RequestMatcherType? earlyMatcherType = null) : base(requestMatchers, type)
         {
-            EarlyMatcherSelector = earlyMatcherSelector;
+            EarlyMatcherType = earlyMatcherType;
         }
     }
 
@@ -96,7 +96,7 @@ public class RequestMessageCompositeMatcherTests
         var requestMessage = new RequestMessage(new UrlDetails("http://localhost"), HttpRequestMethod.GET, "127.0.0.1");
         var matcher = new Helper(
             [requestMatcher1Mock.Object, requestMatcher2Mock.Object, postMatcher],
-            earlyMatcherSelector: m => m.OfType<RequestMessageMethodMatcher>().FirstOrDefault());
+            earlyMatcherType: RequestMatcherType.Method);
 
         // Act
         var result = new RequestMatchResult();

--- a/test/WireMock.Net.Tests/RequestMatchers/RequestMessageCompositeMatcherTests.cs
+++ b/test/WireMock.Net.Tests/RequestMatchers/RequestMessageCompositeMatcherTests.cs
@@ -2,8 +2,10 @@
 
 using Moq;
 using WireMock.Constants;
+using WireMock.Matchers;
 using WireMock.Matchers.Request;
 using WireMock.Models;
+using WireMock.RequestBuilders;
 
 namespace WireMock.Net.Tests.RequestMatchers;
 
@@ -108,5 +110,48 @@ public class RequestMessageCompositeMatcherTests
         // Verify
         requestMatcher1Mock.Verify(rm => rm.GetMatchingScore(It.IsAny<RequestMessage>(), It.IsAny<RequestMatchResult>()), Times.Never);
         requestMatcher2Mock.Verify(rm => rm.GetMatchingScore(It.IsAny<RequestMessage>(), It.IsAny<RequestMatchResult>()), Times.Never);
+    }
+
+    [Fact]
+    public void RequestMessageCompositeMatcher_GetMatchingScore_SeveralHeadersEarlyMismatch()
+    {
+        // Assign
+        var headers = new Dictionary<string, string[]>
+        {
+            { "teST", new[] { "x" } },
+            { "teST2", new[] { "z" } }
+        };
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost"), "GET", "127.0.0.1", null, headers);
+        var request = Request.Create()
+            .WithEarlyMismatch(RequestMatcherType.Header)
+            .UsingAnyMethod()
+            .WithHeader("teST", "x")
+            .WithHeader("teST1", ["xx", "yy"])
+            .WithHeader("teST2", ["y", "z"], matchOperator: MatchOperator.And);
+
+        // Act
+        var score = request.GetMatchingScore(requestMessage, new RequestMatchResult());
+
+        // Assert
+        score.Should().Be(0.0d);
+    }
+
+    [Fact]
+    public void RequestMessageCompositeMatcher_GetMatchingScore_SeveralParamEarlyMismatchSuccess()
+    {
+        // Assign
+        var uriWithParams = new Uri("http://localhost?test1=1&test2=2");
+        var requestMessage = new RequestMessage(new UrlDetails(uriWithParams), "GET", "127.0.0.1");
+        var request = Request.Create()
+            .WithEarlyMismatch(RequestMatcherType.Param)
+            .UsingAnyMethod()
+            .WithParam("test1", "1")
+            .WithParam("test2", "2");
+
+        // Act
+        var score = request.GetMatchingScore(requestMessage, new RequestMatchResult());
+
+        // Assert
+        score.Should().Be(1.0d);
     }
 }

--- a/test/WireMock.Net.Tests/RequestMatchers/RequestMessageCompositeMatcherTests.cs
+++ b/test/WireMock.Net.Tests/RequestMatchers/RequestMessageCompositeMatcherTests.cs
@@ -1,6 +1,7 @@
 // Copyright © WireMock.Net
 
 using Moq;
+using WireMock.Constants;
 using WireMock.Matchers.Request;
 using WireMock.Models;
 
@@ -10,8 +11,12 @@ public class RequestMessageCompositeMatcherTests
 {
     private class Helper : RequestMessageCompositeMatcher
     {
-        public Helper(IEnumerable<IRequestMatcher> requestMatchers, CompositeMatcherType type = CompositeMatcherType.And) : base(requestMatchers, type)
+        public Helper(
+            IEnumerable<IRequestMatcher> requestMatchers,
+            CompositeMatcherType type = CompositeMatcherType.And,
+            Func<IEnumerable<IRequestMatcher>, IRequestMatcher?>? earlyMatcherSelector = null) : base(requestMatchers, type)
         {
+            EarlyMatcherSelector = earlyMatcherSelector;
         }
     }
 
@@ -76,5 +81,32 @@ public class RequestMessageCompositeMatcherTests
         // Verify
         requestMatcher1Mock.Verify(rm => rm.GetMatchingScore(It.IsAny<RequestMessage>(), It.IsAny<RequestMatchResult>()), Times.Once);
         requestMatcher2Mock.Verify(rm => rm.GetMatchingScore(It.IsAny<RequestMessage>(), It.IsAny<RequestMatchResult>()), Times.Once);
+    }
+
+    [Fact]
+    public void RequestMessageCompositeMatcher_GetMatchingScore_EarlyMismatch()
+    {
+        // Assign
+        var requestMatcher1Mock = new Mock<IRequestMatcher>();
+        requestMatcher1Mock.Setup(rm => rm.GetMatchingScore(It.IsAny<RequestMessage>(), It.IsAny<RequestMatchResult>())).Returns(1.0d);
+        var requestMatcher2Mock = new Mock<IRequestMatcher>();
+        requestMatcher2Mock.Setup(rm => rm.GetMatchingScore(It.IsAny<RequestMessage>(), It.IsAny<RequestMatchResult>())).Returns(0.8d);
+        var postMatcher = new RequestMessageMethodMatcher(HttpRequestMethod.POST);
+
+        var requestMessage = new RequestMessage(new UrlDetails("http://localhost"), HttpRequestMethod.GET, "127.0.0.1");
+        var matcher = new Helper(
+            [requestMatcher1Mock.Object, requestMatcher2Mock.Object, postMatcher],
+            earlyMatcherSelector: m => m.OfType<RequestMessageMethodMatcher>().FirstOrDefault());
+
+        // Act
+        var result = new RequestMatchResult();
+        double score = matcher.GetMatchingScore(requestMessage, result);
+
+        // Assert
+        score.Should().Be(0.0d);
+
+        // Verify
+        requestMatcher1Mock.Verify(rm => rm.GetMatchingScore(It.IsAny<RequestMessage>(), It.IsAny<RequestMatchResult>()), Times.Never);
+        requestMatcher2Mock.Verify(rm => rm.GetMatchingScore(It.IsAny<RequestMessage>(), It.IsAny<RequestMatchResult>()), Times.Never);
     }
 }

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode.cs
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode.cs
@@ -1,5 +1,6 @@
 // Copyright © WireMock.Net
 
+using WireMock.Matchers.Request;
 using WireMock.Net.Tests.VerifyExtensions;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -101,6 +102,7 @@ public partial class MappingConverterTests
         var guid = new Guid("8e7b9ab7-e18e-4502-8bc9-11e6679811cc");
         var request = Request.Create()
             .UsingGet()
+            .WithEarlyMismatch(RequestMatcherType.Method)
             .WithPath("/test_path")
             .WithParam("q", "42")
             .WithClientIP("112.123.100.99")

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsFalse.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsFalse.verified.txt
@@ -1,5 +1,6 @@
 ﻿builder
     .Given(Request.Create()
+        .WithEarlyMismatch(RequestMatcherType.Method)
         .UsingMethod("GET")
         .WithPath(new WildcardMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, "/test_path", false, WireMock.Matchers.MatchOperator.Or))
         .WithParam("q", new ExactMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, false, WireMock.Matchers.MatchOperator.And, "42"))

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsFalse.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsFalse.verified.txt
@@ -1,6 +1,6 @@
 ﻿builder
     .Given(Request.Create()
-        .WithEarlyMismatch(RequestMatcherType.Method)
+        .WithEarlyMismatch(WireMock.Matchers.Request.RequestMatcherType.Method)
         .UsingMethod("GET")
         .WithPath(new WildcardMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, "/test_path", false, WireMock.Matchers.MatchOperator.Or))
         .WithParam("q", new ExactMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, false, WireMock.Matchers.MatchOperator.And, "42"))

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsTrue.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsTrue.verified.txt
@@ -1,7 +1,7 @@
 ﻿var builder = new MappingBuilder();
 builder
     .Given(Request.Create()
-        .WithEarlyMismatch(RequestMatcherType.Method)
+        .WithEarlyMismatch(WireMock.Matchers.Request.RequestMatcherType.Method)
         .UsingMethod("GET")
         .WithPath(new WildcardMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, "/test_path", false, WireMock.Matchers.MatchOperator.Or))
         .WithParam("q", new ExactMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, false, WireMock.Matchers.MatchOperator.And, "42"))

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsTrue.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Builder_And_AddStartIsTrue.verified.txt
@@ -1,6 +1,7 @@
 ﻿var builder = new MappingBuilder();
 builder
     .Given(Request.Create()
+        .WithEarlyMismatch(RequestMatcherType.Method)
         .UsingMethod("GET")
         .WithPath(new WildcardMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, "/test_path", false, WireMock.Matchers.MatchOperator.Or))
         .WithParam("q", new ExactMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, false, WireMock.Matchers.MatchOperator.And, "42"))

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsFalse.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsFalse.verified.txt
@@ -1,5 +1,6 @@
 ﻿server
     .Given(Request.Create()
+        .WithEarlyMismatch(RequestMatcherType.Method)
         .UsingMethod("GET")
         .WithPath(new WildcardMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, "/test_path", false, WireMock.Matchers.MatchOperator.Or))
         .WithParam("q", new ExactMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, false, WireMock.Matchers.MatchOperator.And, "42"))

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsFalse.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsFalse.verified.txt
@@ -1,6 +1,6 @@
 ﻿server
     .Given(Request.Create()
-        .WithEarlyMismatch(RequestMatcherType.Method)
+        .WithEarlyMismatch(WireMock.Matchers.Request.RequestMatcherType.Method)
         .UsingMethod("GET")
         .WithPath(new WildcardMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, "/test_path", false, WireMock.Matchers.MatchOperator.Or))
         .WithParam("q", new ExactMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, false, WireMock.Matchers.MatchOperator.And, "42"))

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsTrue.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsTrue.verified.txt
@@ -1,6 +1,7 @@
 ﻿var server = WireMockServer.Start();
 server
     .Given(Request.Create()
+        .WithEarlyMismatch(RequestMatcherType.Method)
         .UsingMethod("GET")
         .WithPath(new WildcardMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, "/test_path", false, WireMock.Matchers.MatchOperator.Or))
         .WithParam("q", new ExactMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, false, WireMock.Matchers.MatchOperator.And, "42"))

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsTrue.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToCSharpCode_With_Server_And_AddStartIsTrue.verified.txt
@@ -1,7 +1,7 @@
 ﻿var server = WireMockServer.Start();
 server
     .Given(Request.Create()
-        .WithEarlyMismatch(RequestMatcherType.Method)
+        .WithEarlyMismatch(WireMock.Matchers.Request.RequestMatcherType.Method)
         .UsingMethod("GET")
         .WithPath(new WildcardMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, "/test_path", false, WireMock.Matchers.MatchOperator.Or))
         .WithParam("q", new ExactMatcher(WireMock.Matchers.MatchBehaviour.AcceptOnMatch, false, WireMock.Matchers.MatchOperator.And, "42"))

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToMappingModel_Request_WithBodyAsGraphQLSchema_ReturnsCorrectModel.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToMappingModel_Request_WithBodyAsGraphQLSchema_ReturnsCorrectModel.verified.txt
@@ -19,7 +19,7 @@
    id:ID!
    firstName:String
    lastName:String
-   fullName:String 
+   fullName:String
   }
       }
     }

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToMappingModel_Request_WithEarlyMismatch_ReturnsCorrectModel.verified.txt
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.ToMappingModel_Request_WithEarlyMismatch_ReturnsCorrectModel.verified.txt
@@ -1,0 +1,34 @@
+﻿{
+  Guid: Guid_1,
+  UpdatedAt: DateTime_1,
+  Title: ,
+  Description: ,
+  Priority: 42,
+  Request: {
+    Path: {
+      Matchers: [
+        {
+          Name: WildcardMatcher,
+          Pattern: 1.2.3.4,
+          IgnoreCase: false
+        }
+      ]
+    },
+    Headers: [
+      {
+        Name: x1,
+        Matchers: [
+          {
+            Name: WildcardMatcher,
+            Pattern: y,
+            IgnoreCase: true
+          }
+        ],
+        IgnoreCase: true
+      }
+    ],
+    EarlyMatcherType: ClientIP
+  },
+  Response: {},
+  UseWebhooksFireAndForget: false
+}

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.cs
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.cs
@@ -1,6 +1,7 @@
 // Copyright © WireMock.Net
 
 using WireMock.Matchers;
+using WireMock.Matchers.Request;
 using WireMock.Models;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -538,7 +539,7 @@ message HelloReply {
    id:ID!
    firstName:String
    lastName:String
-   fullName:String 
+   fullName:String
   }";
         var request = Request.Create().WithGraphQLSchema(schema);
         var response = Response.Create();
@@ -636,6 +637,27 @@ message HelloReply {
 
         // Assert
         model.Should().NotBeNull();
+
+        // Verify
+        return Verify(model);
+    }
+
+    [Fact]
+    public Task ToMappingModel_Request_WithEarlyMismatch_ReturnsCorrectModel()
+    {
+        // Arrange
+        var request = Request.Create().WithEarlyMismatch(RequestMatcherType.ClientIP)
+            .WithHeader("x1", "y")
+            .WithClientIP("1.2.3.4");
+        var response = Response.Create();
+        var mapping = new Mapping(_guid, _updatedAt, string.Empty, string.Empty, null, _settings, request, response, 42, null, null, null, null, null, false, null, null);
+
+        // Act
+        var model = _sut.ToMappingModel(mapping);
+
+        // Assert
+        model.Should().NotBeNull();
+        model.Request.EarlyMatcherType.Should().Be(nameof(RequestMatcherType.ClientIP));
 
         // Verify
         return Verify(model);

--- a/test/WireMock.Net.Tests/Serialization/MappingConverterTests.cs
+++ b/test/WireMock.Net.Tests/Serialization/MappingConverterTests.cs
@@ -657,7 +657,7 @@ message HelloReply {
 
         // Assert
         model.Should().NotBeNull();
-        model.Request.EarlyMatcherType.Should().Be(nameof(RequestMatcherType.ClientIP));
+        model.Request.EarlyMatcherType.Should().Be(RequestMatcherType.ClientIP);
 
         // Verify
         return Verify(model);


### PR DESCRIPTION
## Description

- added new method `WireMock.RequestBuilders.IRequestBuilder.WithEarlyMismatch`
- covered feature with tests (`WireMockServerTests.Grpc` and `RequestMessageCompositeMatcherTests`)

Method `WithEarlyMismatch` sets selector which chooses matcher to return immediate mismatch during mapping processing.
Selector is a `Func` delegate run on available matchers.

## References

Closes #1442 
