### PR TITLE
chore: update Handlebars 2.5.2 to 2.5.5

### DIFF
--- a/src/WireMock.Net.Shared/WireMock.Net.Shared.csproj
+++ b/src/WireMock.Net.Shared/WireMock.Net.Shared.csproj
@@ -34,14 +34,14 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Handlebars.Net.Helpers" Version="2.5.2" />
+        <PackageReference Include="Handlebars.Net.Helpers" Version="2.5.5" />
         <!--<PackageReference Include="Handlebars.Net.Helpers.DynamicLinq" Version="2.5.2" />-->
-        <PackageReference Include="Handlebars.Net.Helpers.Humanizer" Version="2.5.2" />
-        <PackageReference Include="Handlebars.Net.Helpers.Json" Version="2.5.2" />
-        <PackageReference Include="Handlebars.Net.Helpers.Random" Version="2.5.2" />
-        <PackageReference Include="Handlebars.Net.Helpers.Xeger" Version="2.5.2" />
-        <PackageReference Include="Handlebars.Net.Helpers.XPath" Version="2.5.2" />
-        <PackageReference Include="Handlebars.Net.Helpers.Xslt" Version="2.5.2" />
+        <PackageReference Include="Handlebars.Net.Helpers.Humanizer" Version="2.5.5" />
+        <PackageReference Include="Handlebars.Net.Helpers.Json" Version="2.5.5" />
+        <PackageReference Include="Handlebars.Net.Helpers.Random" Version="2.5.5" />
+        <PackageReference Include="Handlebars.Net.Helpers.Xeger" Version="2.5.5" />
+        <PackageReference Include="Handlebars.Net.Helpers.XPath" Version="2.5.5" />
+        <PackageReference Include="Handlebars.Net.Helpers.Xslt" Version="2.5.5" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

## References

#1458 upgrade handlebars to latest version to remove build warnings in projects using wiremock when using V3 of Humanizer

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)