### PR TITLE
Update Testcontainers nuget package to 4.12.0

### DIFF
--- a/examples/WireMock.Net.TestcontainersExample/Program.cs
+++ b/examples/WireMock.Net.TestcontainersExample/Program.cs
@@ -246,8 +246,8 @@ internal class Program
             throw new InvalidOperationException($"The {nameof(TestcontainersSettings.OS.DockerEndpointAuthConfig)} is null. Check if Docker is started.");
         }
 
-        using var dockerClientConfig = TestcontainersSettings.OS.DockerEndpointAuthConfig.GetDockerClientConfiguration();
-        using var dockerClient = dockerClientConfig.CreateClient();
+        var dockerClientBuilder = TestcontainersSettings.OS.DockerEndpointAuthConfig.GetDockerClientBuilder();
+        using var dockerClient = dockerClientBuilder.Build();
 
         var version = await dockerClient.System.GetVersionAsync();
         return version.Os.IndexOf("Windows", StringComparison.OrdinalIgnoreCase) >= 0 ? OSPlatform.Windows : OSPlatform.Linux;

--- a/src/WireMock.Net.Testcontainers/Utils/TestcontainersUtils.cs
+++ b/src/WireMock.Net.Testcontainers/Utils/TestcontainersUtils.cs
@@ -22,8 +22,8 @@ public static class TestcontainersUtils
             throw new InvalidOperationException($"The {nameof(TestcontainersSettings.OS.DockerEndpointAuthConfig)} is null. Check if Docker is started.");
         }
 
-        using var dockerClientConfig = TestcontainersSettings.OS.DockerEndpointAuthConfig.GetDockerClientConfiguration();
-        using var dockerClient = dockerClientConfig.CreateClient();
+        var dockerClientBuilder = TestcontainersSettings.OS.DockerEndpointAuthConfig.GetDockerClientBuilder();
+        using var dockerClient = dockerClientBuilder.Build();
 
         var version = await dockerClient.System.GetVersionAsync();
         return version.Os.IndexOf("Windows", StringComparison.OrdinalIgnoreCase) >= 0 ? OSPlatform.Windows : OSPlatform.Linux;

--- a/src/WireMock.Net.Testcontainers/WireMock.Net.Testcontainers.csproj
+++ b/src/WireMock.Net.Testcontainers/WireMock.Net.Testcontainers.csproj
@@ -39,7 +39,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Stef.Validation" Version="0.2.0" />
-        <PackageReference Include="Testcontainers" Version="4.10.0" />
+        <PackageReference Include="Testcontainers" Version="4.12.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updates Testcontainers nuget package to 4.12.0 and fix breaking changes as Testcontainers now uses Docker.DotNet.Enhanced instead of Docker.DotNet.

## References

- https://github.com/testcontainers/Docker.DotNet/pull/65/changes#diff-47866ccf8b0e7847797f0307137036fc2608128c2dfac9f33bb746710934303d
- https://github.com/testcontainers/Docker.DotNet/pull/65/changes#diff-a944f48314882e7cae293af14f782fdae674e6af5e12fc2f0abeb705cd3c17b7

## Submitter checklist

- [ ] Recommended: Join [WireMock Slack](https://slack.wiremock.org/) to get any help in `#help-contributing` or a project-specific channel like `#wiremock-java`
- [x] The PR request is well described and justified, including the body and the references
- [x] The PR title represents the desired changelog entry
- [x] The repository's code style is followed (see the contributing guide)
- [x] Test coverage that demonstrates that the change works as expected
- [x] For new features, there's necessary documentation in this pull request or in a subsequent PR to [wiremock.org](https://github.com/wiremock/wiremock.org)
